### PR TITLE
Add "template" handlebars helper

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/core/Fragment.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/core/Fragment.java
@@ -52,6 +52,10 @@ public class Fragment {
         return simpleName;
     }
 
+    public Renderable getRenderable() {
+        return renderer;
+    }
+
     public String render(Model model, Lookup lookup, RequestLookup requestLookup, API api) {
         if (isSecured && !api.getSession().isPresent()) {
             if (requestLookup.tracker().isInPage() || requestLookup.tracker().isInLayout() ||

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/core/HbsRenderable.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/core/HbsRenderable.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.MenuHelper;
 import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.MissingHelper;
 import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.PublicHelper;
 import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.SecuredHelper;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.TemplateHelper;
 import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.TitleHelper;
 import org.wso2.carbon.uuf.spi.Renderable;
 import org.wso2.carbon.uuf.spi.model.Model;
@@ -69,6 +70,7 @@ public abstract class HbsRenderable implements Renderable {
         HANDLEBARS.registerHelper(HeadOtherHelper.HELPER_NAME, new HeadOtherHelper());
         HANDLEBARS.registerHelper(JsHelper.HELPER_NAME, new JsHelper());
         HANDLEBARS.registerHelper(I18nHelper.HELPER_NAME, new I18nHelper());
+        HANDLEBARS.registerHelper(TemplateHelper.HELPER_NAME, new TemplateHelper());
         HANDLEBARS.registerHelperMissing(new MissingHelper());
     }
 
@@ -82,7 +84,7 @@ public abstract class HbsRenderable implements Renderable {
         this.relativePath = relativePath;
     }
 
-    protected Template getTemplate() {
+    public Template getTemplate() {
         return template;
     }
 

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/TemplateHelper.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/TemplateHelper.java
@@ -28,7 +28,6 @@ import org.wso2.carbon.uuf.renderablecreator.hbs.core.HbsRenderable;
 import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.FillPlaceholderHelper;
 
 import java.io.IOException;
-import java.util.Optional;
 
 /**
  * Helper class to embed handlebars fragment template inside a <script> HTML tag and send it to client side.

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/TemplateHelper.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/TemplateHelper.java
@@ -15,6 +15,7 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+
 package org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime;
 
 import com.github.jknack.handlebars.Options;
@@ -47,18 +48,18 @@ public class TemplateHelper extends FillPlaceholderHelper<String> {
         String scriptText;
         if (TagType.VAR.equals(options.tagType)) { // fragment template name is provided
             if (options.params.length < 1) {
-                throw new UUFException("Fragment name is not given in the template");
+                throw new UUFException("Fragment name is not given in the template helper.");
             }
             String fragmentName = options.param(0).toString();
             Lookup lookup = options.data(HbsRenderable.DATA_KEY_LOOKUP);
             RequestLookup requestLookup = options.data(HbsRenderable.DATA_KEY_REQUEST_LOOKUP);
             String componentName = requestLookup.tracker().getCurrentComponentName();
             Fragment fragment = lookup.getFragmentIn(componentName, fragmentName)
-                    .orElseThrow(() -> new UUFException("Cannot find the fragment with the given name '" +
-                            fragmentName + "' from the component '" + componentName + "'"));
+                    .orElseThrow(() -> new UUFException("Fragment '" + fragmentName + "' does not exist in " +
+                            "component '" + componentName + "' or its dependencies."));
             if (!(fragment.getRenderable() instanceof HbsRenderable)) {
-                throw new UUFException("Renderable for the fragment " + fragmentName + " is not an instance of " +
-                        "HbsRenderable");
+                throw new UUFException("The template of the fragment '" + fragmentName + "' is not a handlebars " +
+                        "template.");
             }
             scriptText = "\n" + ((HbsRenderable) fragment.getRenderable()).getTemplate().text() + "\n";
         } else { // fragment is defined inline

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/TemplateHelper.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/TemplateHelper.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime;
+
+import com.github.jknack.handlebars.Options;
+import com.github.jknack.handlebars.TagType;
+import org.wso2.carbon.uuf.api.Placeholder;
+import org.wso2.carbon.uuf.core.Fragment;
+import org.wso2.carbon.uuf.core.Lookup;
+import org.wso2.carbon.uuf.core.RequestLookup;
+import org.wso2.carbon.uuf.exception.UUFException;
+import org.wso2.carbon.uuf.renderablecreator.hbs.core.HbsRenderable;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.FillPlaceholderHelper;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * Helper class to embed handlebars fragment template inside a <script> HTML tag and send it to client side.
+ *
+ * @since 1.0.0
+ */
+public class TemplateHelper extends FillPlaceholderHelper<String> {
+
+    public static final String HELPER_NAME = "template";
+
+    public TemplateHelper() {
+        super(Placeholder.js);
+    }
+
+    @Override
+    public CharSequence apply(String templateName, Options options) throws IOException {
+        String scriptText;
+        if (TagType.VAR.equals(options.tagType)) { // fragment template name is provided
+            if (options.params.length < 1) {
+                throw new UUFException("Fragment name is not given in the template");
+            }
+            String fragmentName = options.param(0).toString();
+            Lookup lookup = options.data(HbsRenderable.DATA_KEY_LOOKUP);
+            RequestLookup requestLookup = options.data(HbsRenderable.DATA_KEY_REQUEST_LOOKUP);
+            String componentName = requestLookup.tracker().getCurrentComponentName();
+            Fragment fragment = lookup.getFragmentIn(componentName, fragmentName)
+                    .orElseThrow(() -> new UUFException("Cannot find the fragment with the given name '" +
+                            fragmentName + "' from the component '" + componentName + "'"));
+            if (!(fragment.getRenderable() instanceof HbsRenderable)) {
+                throw new UUFException("Renderable for the fragment " + fragmentName + " is not an instance of " +
+                        "HbsRenderable");
+            }
+            scriptText = "\n" + ((HbsRenderable) fragment.getRenderable()).getTemplate().text() + "\n";
+        } else { // fragment is defined inline
+            scriptText = options.fn.text();
+        }
+
+        String script = "<script id=\"" + templateName + "\" type=\"text/x-handlebars-template\">" + scriptText +
+                "</script>";
+        addToPlaceholder(script, options);
+        return "";
+    }
+}

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/MutableHbsFragmentRenderable.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/MutableHbsFragmentRenderable.java
@@ -49,7 +49,7 @@ public class MutableHbsFragmentRenderable extends HbsFragmentRenderable implemen
     }
 
     @Override
-    protected Template getTemplate() {
+    public Template getTemplate() {
         return template;
     }
 

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/MutableHbsLayoutRenderable.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/MutableHbsLayoutRenderable.java
@@ -43,7 +43,7 @@ public class MutableHbsLayoutRenderable extends HbsLayoutRenderable implements M
     }
 
     @Override
-    protected Template getTemplate() {
+    public Template getTemplate() {
         return template;
     }
 

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/MutableHbsPageRenderable.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/MutableHbsPageRenderable.java
@@ -47,7 +47,7 @@ public class MutableHbsPageRenderable extends HbsPageRenderable implements Mutab
     }
 
     @Override
-    protected Template getTemplate() {
+    public Template getTemplate() {
         return template;
     }
 

--- a/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/handlebars/HbsHelperTest.java
+++ b/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/handlebars/HbsHelperTest.java
@@ -225,6 +225,24 @@ public class HbsHelperTest {
             Assert.assertEquals(error.line, 3, "error is in the 3rd line");
             Assert.assertEquals(error.column, 2, "error is in the 2nd column");
         }
+    }
 
+    @Test
+    public void testInlineFragmentTemplate() {
+        RequestLookup requestLookup = createRequestLookup();
+        String templateName = "someName";
+        String scriptText = "<div class=\"col-md-12\">\n" +
+                "    {{#each devices}}\n" +
+                "        <div class=\"device\">\n" +
+                "            <span>Name : {{name}}</span>\n" +
+                "            <span>Type : {{type}}</span>\n" +
+                "        </div>\n" +
+                "    {{/each}}\n" +
+                "</div>";
+        createRenderable("{{#template \"" + templateName + "\"}}\n" + scriptText + "{{/template}}").
+                render(null, createLookup(), requestLookup, createAPI());
+        String expected = "<script id=\"" + templateName + "\" type=\"text/x-handlebars-template\">\n" + scriptText +
+                "</script>";
+        Assert.assertEquals(requestLookup.getPlaceholderContent(Placeholder.js).get(), expected);
     }
 }

--- a/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/handlebars/HbsHelperTest.java
+++ b/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/handlebars/HbsHelperTest.java
@@ -19,13 +19,19 @@ package org.wso2.carbon.uuf.handlebars;
 import com.github.jknack.handlebars.HandlebarsError;
 import com.github.jknack.handlebars.HandlebarsException;
 import com.github.jknack.handlebars.io.StringTemplateSource;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.ImmutableSortedSet;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.wso2.carbon.uuf.api.Configuration;
 import org.wso2.carbon.uuf.api.Placeholder;
 import org.wso2.carbon.uuf.core.API;
+import org.wso2.carbon.uuf.core.Component;
+import org.wso2.carbon.uuf.core.Fragment;
 import org.wso2.carbon.uuf.core.Lookup;
+import org.wso2.carbon.uuf.core.Page;
 import org.wso2.carbon.uuf.core.RequestLookup;
+import org.wso2.carbon.uuf.internal.core.UriPatten;
 import org.wso2.carbon.uuf.renderablecreator.hbs.core.HbsRenderable;
 import org.wso2.carbon.uuf.renderablecreator.hbs.impl.HbsPageRenderable;
 import org.wso2.carbon.uuf.spi.HttpRequest;
@@ -230,7 +236,7 @@ public class HbsHelperTest {
     @Test
     public void testInlineFragmentTemplate() {
         RequestLookup requestLookup = createRequestLookup();
-        String templateName = "someName";
+        String templateName = "testTemplateName";
         String scriptText = "<div class=\"col-md-12\">\n" +
                 "    {{#each devices}}\n" +
                 "        <div class=\"device\">\n" +
@@ -243,6 +249,33 @@ public class HbsHelperTest {
                 render(null, createLookup(), requestLookup, createAPI());
         String expected = "<script id=\"" + templateName + "\" type=\"text/x-handlebars-template\">\n" + scriptText +
                 "</script>";
+        Assert.assertEquals(requestLookup.getPlaceholderContent(Placeholder.js).get(), expected);
+    }
+
+    @Test
+    public void testReferencedFragmentTemplate() {
+        String templateName = "testTemplateName";
+        String componentName = "test.componentName";
+        String fragmentName = componentName + ".fragmentName";
+        String pageContent = "{{template \"" + templateName + "\" \"" + fragmentName + "\"}}";
+        String fragmentContent = "<div class=\"col-md-12\">\n" +
+                "    {{#each devices}}\n" +
+                "        <div class=\"device\">\n" +
+                "            <span>Name : {{name}}</span>\n" +
+                "            <span>Type : {{type}}</span>\n" +
+                "        </div>\n" +
+                "    {{/each}}\n" +
+                "</div>";
+        Fragment fragment = new Fragment(fragmentName, createRenderable(fragmentContent), false);
+        Page page = new Page(new UriPatten("/contextPath"), createRenderable(pageContent), false);
+        Component component = new Component(componentName, null, null, ImmutableSortedSet.of(page), null);
+        Lookup lookup = new Lookup(ImmutableSetMultimap.of());
+        lookup.add(fragment);
+        lookup.add(component);
+        RequestLookup requestLookup = createRequestLookup();
+        component.renderPage("/contextPath", null, lookup, requestLookup, createAPI());
+        String expected = "<script id=\"" + templateName + "\" type=\"text/x-handlebars-template\">\n" +
+                fragmentContent + "\n</script>";
         Assert.assertEquals(requestLookup.getPlaceholderContent(Placeholder.js).get(), expected);
     }
 }

--- a/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/handlebars/HbsHelperTest.java
+++ b/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/handlebars/HbsHelperTest.java
@@ -266,11 +266,10 @@ public class HbsHelperTest {
                 "        </div>\n" +
                 "    {{/each}}\n" +
                 "</div>";
-        Fragment fragment = new Fragment(fragmentName, createRenderable(fragmentContent), false);
         Page page = new Page(new UriPatten("/contextPath"), createRenderable(pageContent), false);
         Component component = new Component(componentName, null, null, ImmutableSortedSet.of(page), null);
         Lookup lookup = new Lookup(ImmutableSetMultimap.of());
-        lookup.add(fragment);
+        lookup.add(new Fragment(fragmentName, createRenderable(fragmentContent), false));
         lookup.add(component);
         RequestLookup requestLookup = createRequestLookup();
         component.renderPage("/contextPath", null, lookup, requestLookup, createAPI());


### PR DESCRIPTION
This PR adds a new handlebar helper, "template", to send fragments templates safely from server side to client side. This fixes #74 

Syntax of the helper is as follows.

 - defining the template inline.
```hbs
{{#template <clientSideName>}}
  <div>
     <!-- inline template content -->
  </div>
{{/template}}
```
- using a already defined fragment within the template.
```hbs
{{template <clientSideName> <fragmentName>}}
```


