### PR TITLE
add helper registry with all default & custom helpers

### DIFF
--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/core/HbsRenderable.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/core/HbsRenderable.java
@@ -23,22 +23,7 @@ import org.wso2.carbon.uuf.core.API;
 import org.wso2.carbon.uuf.core.Lookup;
 import org.wso2.carbon.uuf.core.RequestLookup;
 import org.wso2.carbon.uuf.exception.UUFException;
-import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.CssHelper;
-import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.DefinePlaceholderHelper;
-import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.DefineZoneHelper;
-import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.FaviconHelper;
-import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.FillZoneHelper;
-import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.FragmentHelper;
-import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.HeadJsHelper;
-import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.HeadOtherHelper;
-import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.I18nHelper;
-import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.JsHelper;
-import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.MenuHelper;
-import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.MissingHelper;
-import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.PublicHelper;
-import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.SecuredHelper;
-import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.TemplateHelper;
-import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.TitleHelper;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.registry.HbsHelperRegistry;
 import org.wso2.carbon.uuf.spi.Renderable;
 import org.wso2.carbon.uuf.spi.model.Model;
 
@@ -53,26 +38,7 @@ public abstract class HbsRenderable implements Renderable {
     public static final String DATA_KEY_REQUEST_LOOKUP = HbsRenderable.class.getName() + "#request-lookup";
     public static final String DATA_KEY_API = HbsRenderable.class.getName() + "#api";
     public static final String DATA_KEY_CURRENT_WRITER = HbsRenderable.class.getName() + "#writer";
-    private static final Handlebars HANDLEBARS = new Handlebars();
-
-    static {
-        HANDLEBARS.registerHelper(FragmentHelper.HELPER_NAME, new FragmentHelper());
-        HANDLEBARS.registerHelper(SecuredHelper.HELPER_NAME, new SecuredHelper());
-        HANDLEBARS.registerHelper(PublicHelper.HELPER_NAME, new PublicHelper());
-        HANDLEBARS.registerHelper(MenuHelper.HELPER_NAME, new MenuHelper());
-        HANDLEBARS.registerHelper(DefineZoneHelper.HELPER_NAME, new DefineZoneHelper());
-        HANDLEBARS.registerHelper(FillZoneHelper.HELPER_NAME, new FillZoneHelper());
-        HANDLEBARS.registerHelper(DefinePlaceholderHelper.HELPER_NAME, new DefinePlaceholderHelper());
-        HANDLEBARS.registerHelper(FaviconHelper.HELPER_NAME, new FaviconHelper());
-        HANDLEBARS.registerHelper(TitleHelper.HELPER_NAME, new TitleHelper());
-        HANDLEBARS.registerHelper(CssHelper.HELPER_NAME, new CssHelper());
-        HANDLEBARS.registerHelper(HeadJsHelper.HELPER_NAME, new HeadJsHelper());
-        HANDLEBARS.registerHelper(HeadOtherHelper.HELPER_NAME, new HeadOtherHelper());
-        HANDLEBARS.registerHelper(JsHelper.HELPER_NAME, new JsHelper());
-        HANDLEBARS.registerHelper(I18nHelper.HELPER_NAME, new I18nHelper());
-        HANDLEBARS.registerHelper(TemplateHelper.HELPER_NAME, new TemplateHelper());
-        HANDLEBARS.registerHelperMissing(new MissingHelper());
-    }
+    private static final Handlebars HANDLEBARS = new Handlebars().with(new HbsHelperRegistry());
 
     private final Template template;
     private final String absolutePath;

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/registry/HbsHelperRegistry.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/registry/HbsHelperRegistry.java
@@ -61,7 +61,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.URI;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -81,7 +80,7 @@ public class HbsHelperRegistry implements HelperRegistry {
     /**
      * The helper registry.
      */
-    private final Map<String, Helper<?>> helpers = new HashMap<String, Helper<?>>();
+    private final Map<String, Helper<?>> helpers = new HashMap<>();
 
     /**
      * Decorators.
@@ -199,7 +198,6 @@ public class HbsHelperRegistry implements HelperRegistry {
      */
     private void registerDynamicHelper(final Object source, final Class<?> clazz) {
         if (clazz != Object.class) {
-            Set<String> overloaded = new HashSet<String>();
             // Keep backing up the inheritance hierarchy.
             Method[] methods = clazz.getDeclaredMethods();
             for (Method method : methods) {

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/registry/HbsHelperRegistry.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/registry/HbsHelperRegistry.java
@@ -1,0 +1,279 @@
+/*
+ *  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.uuf.renderablecreator.hbs.helpers.registry;
+
+import com.github.jknack.handlebars.Decorator;
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.HelperRegistry;
+import com.github.jknack.handlebars.helper.BlockHelper;
+import com.github.jknack.handlebars.helper.EachHelper;
+import com.github.jknack.handlebars.helper.IfHelper;
+import com.github.jknack.handlebars.helper.InlineDecorator;
+import com.github.jknack.handlebars.helper.LogHelper;
+import com.github.jknack.handlebars.helper.LookupHelper;
+import com.github.jknack.handlebars.helper.MethodHelper;
+import com.github.jknack.handlebars.helper.PrecompileHelper;
+import com.github.jknack.handlebars.helper.StringHelpers;
+import com.github.jknack.handlebars.helper.UnlessHelper;
+import com.github.jknack.handlebars.helper.WithHelper;
+import com.github.jknack.handlebars.internal.Files;
+import com.github.jknack.handlebars.js.HandlebarsJs;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.CssHelper;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.DefinePlaceholderHelper;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.DefineZoneHelper;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.FaviconHelper;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.FillZoneHelper;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.FragmentHelper;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.HeadJsHelper;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.HeadOtherHelper;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.I18nHelper;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.JsHelper;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.MenuHelper;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.MissingHelper;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.PublicHelper;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.SecuredHelper;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.TemplateHelper;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.TitleHelper;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.Reader;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Default implementation of {@link HelperRegistry} used in UUF.
+ * Reusing the same code from {@link com.github.jknack.handlebars.helper.DefaultHelperRegistry} and additionally
+ * including helpers written for UUF.
+ *
+ * @since 1.0.0
+ */
+public class HbsHelperRegistry implements HelperRegistry {
+    /**
+     * The logging system.
+     */
+    private final Logger logger = LoggerFactory.getLogger(HelperRegistry.class);
+
+    /**
+     * The helper registry.
+     */
+    private final Map<String, Helper<?>> helpers = new HashMap<String, Helper<?>>();
+
+    /**
+     * Decorators.
+     */
+    private final Map<String, Decorator> decorators = new HashMap<>();
+
+    /**
+     * A Handlebars.js implementation.
+     */
+    private HandlebarsJs handlebarsJs = HandlebarsJs.create(this);
+
+    {
+        // make sure default helpers are registered
+        registerDefaultHelpers(this);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <C> Helper<C> helper(final String name) {
+        return (Helper<C>) helpers.get(name);
+    }
+
+    @Override
+    public <H> HelperRegistry registerHelper(final String name, final Helper<H> helper) {
+        Helper<?> oldHelper = helpers.put(name, helper);
+        if (oldHelper != null) {
+            logger.warn("Helper '{}' has been replaced by '{}'", name, helper);
+        }
+        return this;
+    }
+
+    @Override
+    public <H> HelperRegistry registerHelperMissing(final Helper<H> helper) {
+        return registerHelper(Handlebars.HELPER_MISSING, helper);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public HelperRegistry registerHelpers(final Object helperSource) {
+        try {
+            if (helperSource instanceof File) {
+                // adjust to File version
+                return registerHelpers((File) helperSource);
+            } else if (helperSource instanceof URI) {
+                // adjust to URI version
+                return registerHelpers((URI) helperSource);
+            } else if (helperSource instanceof Class) {
+                // adjust to Class version
+                return registerHelpers((Class) helperSource);
+            }
+        } catch (RuntimeException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Can't register helpers", ex);
+        }
+        registerDynamicHelper(helperSource, helperSource.getClass());
+        return this;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Override
+    public HelperRegistry registerHelpers(final Class<?> helperSource) {
+        if (Enum.class.isAssignableFrom(helperSource)) {
+            Enum[] helpers = ((Class<Enum>) helperSource).getEnumConstants();
+            for (Enum helper : helpers) {
+                registerHelper(helper.name(), (Helper) helper);
+            }
+        } else {
+            registerDynamicHelper(null, helperSource);
+        }
+        return this;
+    }
+
+    @Override
+    public HelperRegistry registerHelpers(final URI location) throws Exception {
+        return registerHelpers(location.getPath(), Files.read(location.toString()));
+    }
+
+    @Override
+    public HelperRegistry registerHelpers(final File input) throws Exception {
+        return registerHelpers(input.getAbsolutePath(), Files.read(input));
+    }
+
+    @Override
+    public HelperRegistry registerHelpers(final String filename, final Reader source)
+            throws Exception {
+        return registerHelpers(filename, Files.read(source));
+    }
+
+    @Override
+    public HelperRegistry registerHelpers(final String filename, final InputStream source)
+            throws Exception {
+        return registerHelpers(filename, Files.read(source));
+    }
+
+    @Override
+    public HelperRegistry registerHelpers(final String filename, final String source)
+            throws Exception {
+        handlebarsJs.registerHelpers(filename, source);
+        return this;
+    }
+
+    @Override
+    public Set<Map.Entry<String, Helper<?>>> helpers() {
+        return this.helpers.entrySet();
+    }
+
+    /**
+     * <p>
+     * Register all the helper methods for the given helper source.
+     * </p>
+     *
+     * @param source The helper source.
+     * @param clazz  The helper source class.
+     */
+    private void registerDynamicHelper(final Object source, final Class<?> clazz) {
+        if (clazz != Object.class) {
+            Set<String> overloaded = new HashSet<String>();
+            // Keep backing up the inheritance hierarchy.
+            Method[] methods = clazz.getDeclaredMethods();
+            for (Method method : methods) {
+                boolean isPublic = Modifier.isPublic(method.getModifiers());
+                String helperName = method.getName();
+                if (isPublic && CharSequence.class.isAssignableFrom(method.getReturnType())) {
+                    boolean isStatic = Modifier.isStatic(method.getModifiers());
+                    if (source != null || isStatic) {
+                        registerHelper(helperName, new MethodHelper(method, source));
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Register built-in and default helpers. We are not registering some of the unwanted helpers (partial, embedded,
+     * i18n. etc) as they are replaced by the custom helpers written for UUF.
+     *
+     * @param registry The handlebars instance.
+     */
+    private static void registerDefaultHelpers(final HelperRegistry registry) {
+        registry.registerHelper(WithHelper.NAME, WithHelper.INSTANCE);
+        registry.registerHelper(IfHelper.NAME, IfHelper.INSTANCE);
+        registry.registerHelper(UnlessHelper.NAME, UnlessHelper.INSTANCE);
+        registry.registerHelper(EachHelper.NAME, EachHelper.INSTANCE);
+        registry.registerHelper(BlockHelper.NAME, BlockHelper.INSTANCE);
+        registry.registerHelper(PrecompileHelper.NAME, PrecompileHelper.INSTANCE);
+        registry.registerHelper(LookupHelper.NAME, LookupHelper.INSTANCE);
+        registry.registerHelper(LogHelper.NAME, LogHelper.INSTANCE);
+        registry.registerHelper(FragmentHelper.HELPER_NAME, new FragmentHelper());
+        registry.registerHelper(SecuredHelper.HELPER_NAME, new SecuredHelper());
+        registry.registerHelper(PublicHelper.HELPER_NAME, new PublicHelper());
+        registry.registerHelper(MenuHelper.HELPER_NAME, new MenuHelper());
+        registry.registerHelper(DefineZoneHelper.HELPER_NAME, new DefineZoneHelper());
+        registry.registerHelper(FillZoneHelper.HELPER_NAME, new FillZoneHelper());
+        registry.registerHelper(DefinePlaceholderHelper.HELPER_NAME, new DefinePlaceholderHelper());
+        registry.registerHelper(FaviconHelper.HELPER_NAME, new FaviconHelper());
+        registry.registerHelper(TitleHelper.HELPER_NAME, new TitleHelper());
+        registry.registerHelper(CssHelper.HELPER_NAME, new CssHelper());
+        registry.registerHelper(HeadJsHelper.HELPER_NAME, new HeadJsHelper());
+        registry.registerHelper(HeadOtherHelper.HELPER_NAME, new HeadOtherHelper());
+        registry.registerHelper(JsHelper.HELPER_NAME, new JsHelper());
+        registry.registerHelper(I18nHelper.HELPER_NAME, new I18nHelper());
+        registry.registerHelper(TemplateHelper.HELPER_NAME, new TemplateHelper());
+        registry.registerHelpers(StringHelpers.class);
+        registry.registerHelperMissing(new MissingHelper());
+        // decorator
+        registry.registerDecorator("inline", InlineDecorator.INSTANCE);
+    }
+
+    @Override
+    public Decorator decorator(final String name) {
+        return decorators.get(name);
+    }
+
+    @Override
+    public HelperRegistry registerDecorator(final String name, final Decorator decorator) {
+        Decorator old = decorators.put(name, decorator);
+        if (old != null) {
+            logger.warn("Decorator '{}' has been replaced by '{}'", name, decorator);
+        }
+        return this;
+    }
+
+    /**
+     * Set the handlebars Js. This operation will override previously registered
+     * handlebars Js.
+     *
+     * @param handlebarsJs The handlebars Js. Required.
+     * @return This DefaultHelperRegistry object.
+     */
+    public HbsHelperRegistry with(final HandlebarsJs handlebarsJs) {
+        this.handlebarsJs = handlebarsJs;
+        return this;
+    }
+}

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/registry/HbsHelperRegistry.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/registry/HbsHelperRegistry.java
@@ -112,9 +112,17 @@ public class HbsHelperRegistry implements HelperRegistry {
         throw new UnsupportedOperationException();
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public HelperRegistry registerHelpers(final Class<?> helperSource) {
-        throw new UnsupportedOperationException();
+        if (!Enum.class.isAssignableFrom(helperSource)) {
+            throw new UnsupportedOperationException();
+        }
+        Enum[] helpers = ((Class<Enum>) helperSource).getEnumConstants();
+        for (Enum helper : helpers) {
+            registerHelper(helper.name(), (Helper) helper);
+        }
+        return this;
     }
 
     @Override
@@ -166,9 +174,7 @@ public class HbsHelperRegistry implements HelperRegistry {
         registry.registerHelper(PrecompileHelper.NAME, PrecompileHelper.INSTANCE);
         registry.registerHelper(LookupHelper.NAME, LookupHelper.INSTANCE);
         registry.registerHelper(LogHelper.NAME, LogHelper.INSTANCE);
-        for (StringHelpers helper : StringHelpers.values()) {
-            registry.registerHelper(helper.name(), helper);
-        }
+        registry.registerHelpers(StringHelpers.class);
         //UUF related helpers
         registry.registerHelper(FragmentHelper.HELPER_NAME, new FragmentHelper());
         registry.registerHelper(SecuredHelper.HELPER_NAME, new SecuredHelper());

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/registry/HbsHelperRegistry.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/registry/HbsHelperRegistry.java
@@ -228,6 +228,8 @@ public class HbsHelperRegistry implements HelperRegistry {
         registry.registerHelper(PrecompileHelper.NAME, PrecompileHelper.INSTANCE);
         registry.registerHelper(LookupHelper.NAME, LookupHelper.INSTANCE);
         registry.registerHelper(LogHelper.NAME, LogHelper.INSTANCE);
+        registry.registerHelpers(StringHelpers.class);
+        //UUF related helpers
         registry.registerHelper(FragmentHelper.HELPER_NAME, new FragmentHelper());
         registry.registerHelper(SecuredHelper.HELPER_NAME, new SecuredHelper());
         registry.registerHelper(PublicHelper.HELPER_NAME, new PublicHelper());
@@ -243,7 +245,6 @@ public class HbsHelperRegistry implements HelperRegistry {
         registry.registerHelper(JsHelper.HELPER_NAME, new JsHelper());
         registry.registerHelper(I18nHelper.HELPER_NAME, new I18nHelper());
         registry.registerHelper(TemplateHelper.HELPER_NAME, new TemplateHelper());
-        registry.registerHelpers(StringHelpers.class);
         registry.registerHelperMissing(new MissingHelper());
         // decorator
         registry.registerDecorator("inline", InlineDecorator.INSTANCE);

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/registry/HbsHelperRegistry.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/registry/HbsHelperRegistry.java
@@ -28,7 +28,6 @@ import com.github.jknack.handlebars.helper.IfHelper;
 import com.github.jknack.handlebars.helper.InlineDecorator;
 import com.github.jknack.handlebars.helper.LogHelper;
 import com.github.jknack.handlebars.helper.LookupHelper;
-import com.github.jknack.handlebars.helper.PrecompileHelper;
 import com.github.jknack.handlebars.helper.StringHelpers;
 import com.github.jknack.handlebars.helper.UnlessHelper;
 import com.github.jknack.handlebars.helper.WithHelper;
@@ -87,12 +86,18 @@ public class HbsHelperRegistry implements HelperRegistry {
         registerDefaultHelpers(this);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @SuppressWarnings("unchecked")
     @Override
     public <C> Helper<C> helper(final String name) {
         return (Helper<C>) helpers.get(name);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public <H> HelperRegistry registerHelper(final String name, final Helper<H> helper) {
         Helper<?> oldHelper = helpers.put(name, helper);
@@ -102,16 +107,27 @@ public class HbsHelperRegistry implements HelperRegistry {
         return this;
     }
 
+    /**
+     * This method is not supported and not used within UUF.
+     */
     @Override
     public <H> HelperRegistry registerHelperMissing(final Helper<H> helper) {
         return registerHelper(Handlebars.HELPER_MISSING, helper);
     }
 
+    /**
+     * This method is not supported and not used within UUF.
+     */
     @Override
     public HelperRegistry registerHelpers(final Object helperSource) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * This will register only the class source of enum with {@link Helper} implementation.
+     */
     @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public HelperRegistry registerHelpers(final Class<?> helperSource) {
@@ -125,34 +141,52 @@ public class HbsHelperRegistry implements HelperRegistry {
         return this;
     }
 
+    /**
+     * This method is not supported and not used within UUF.
+     */
     @Override
     public HelperRegistry registerHelpers(final URI location) throws Exception {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * This method is not supported and not used within UUF.
+     */
     @Override
     public HelperRegistry registerHelpers(final File input) throws Exception {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * This method is not supported and not used within UUF.
+     */
     @Override
     public HelperRegistry registerHelpers(final String filename, final Reader source)
             throws Exception {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * This method is not supported and not used within UUF.
+     */
     @Override
     public HelperRegistry registerHelpers(final String filename, final InputStream source)
             throws Exception {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * This method is not supported and not used within UUF.
+     */
     @Override
     public HelperRegistry registerHelpers(final String filename, final String source)
             throws Exception {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Set<Map.Entry<String, Helper<?>>> helpers() {
         return this.helpers.entrySet();
@@ -171,7 +205,6 @@ public class HbsHelperRegistry implements HelperRegistry {
         registry.registerHelper(UnlessHelper.NAME, UnlessHelper.INSTANCE);
         registry.registerHelper(EachHelper.NAME, EachHelper.INSTANCE);
         registry.registerHelper(BlockHelper.NAME, BlockHelper.INSTANCE);
-        registry.registerHelper(PrecompileHelper.NAME, PrecompileHelper.INSTANCE);
         registry.registerHelper(LookupHelper.NAME, LookupHelper.INSTANCE);
         registry.registerHelper(LogHelper.NAME, LogHelper.INSTANCE);
         registry.registerHelpers(StringHelpers.class);
@@ -196,11 +229,17 @@ public class HbsHelperRegistry implements HelperRegistry {
         registry.registerDecorator("inline", InlineDecorator.INSTANCE);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Decorator decorator(final String name) {
         return decorators.get(name);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public HelperRegistry registerDecorator(final String name, final Decorator decorator) {
         Decorator old = decorators.put(name, decorator);


### PR DESCRIPTION
adding our own helper registry, by reusing the same code from com.github.jknack.handlebars.helper.DefaultHelperRegistry, so that we can remove the unwanted default helpers that are not needed anymore as we have added our own helpers for them (partial, embedded, i18n). fixes #80.