### PR TITLE
Fix duplicate css and js resource entries in final HTML when a fragment is included more than once

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/core/RequestLookup.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/core/RequestLookup.java
@@ -175,15 +175,15 @@ public class RequestLookup {
             return componentNamesStack.peekLast();
         }
 
-        Optional<Page> getCurrentPage() {
+        public Optional<Page> getCurrentPage() {
             return Optional.ofNullable(pageStack.peekLast());
         }
 
-        Optional<Fragment> getCurrentFragment() {
+        public Optional<Fragment> getCurrentFragment() {
             return Optional.ofNullable(fragmentStack.peekLast());
         }
 
-        Optional<Layout> getCurrentLayout() {
+        public Optional<Layout> getCurrentLayout() {
             return Optional.ofNullable(layoutStack.peekLast());
         }
 

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/core/HbsRenderable.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/core/HbsRenderable.java
@@ -38,6 +38,7 @@ public abstract class HbsRenderable implements Renderable {
     public static final String DATA_KEY_REQUEST_LOOKUP = HbsRenderable.class.getName() + "#request-lookup";
     public static final String DATA_KEY_API = HbsRenderable.class.getName() + "#api";
     public static final String DATA_KEY_CURRENT_WRITER = HbsRenderable.class.getName() + "#writer";
+    public static final String DATA_KEY_RESOLVED_RESOURCES = HbsRenderable.class.getName() + "#resolved-resources";
     private static final Handlebars HANDLEBARS = new Handlebars().with(new HbsHelperRegistry());
 
     private final Template template;

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/FillPlaceholderHelper.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/FillPlaceholderHelper.java
@@ -22,10 +22,12 @@ import org.wso2.carbon.uuf.api.Placeholder;
 import org.wso2.carbon.uuf.core.RequestLookup;
 import org.wso2.carbon.uuf.renderablecreator.hbs.core.HbsRenderable;
 
+import java.util.HashSet;
 import java.util.Optional;
 
 public abstract class FillPlaceholderHelper<T> implements Helper<T> {
 
+    protected static final String RESOLVED_PLACEHOLDERS = "resolvedPlaceholders";
     private final Placeholder placeholder;
 
     protected FillPlaceholderHelper(Placeholder placeholder) {
@@ -44,5 +46,21 @@ public abstract class FillPlaceholderHelper<T> implements Helper<T> {
     protected Optional<String> getPlaceholderValue(Options handlebarsOptions) {
         RequestLookup requestLookup = handlebarsOptions.data(HbsRenderable.DATA_KEY_REQUEST_LOOKUP);
         return requestLookup.getPlaceholderContent(placeholder);
+    }
+
+    /**
+     * Create a {@link HashSet} with the name {@code RESOLVED_PLACEHOLDERS} in handlebars options data if it's not
+     * there. Check whether the given content is already resolved.
+     *
+     * @param options handlebars options to get {@code RESOLVED_PLACEHOLDERS}
+     * @param content content to check for
+     * @return <tt>true</tt> if the placeholder is already resolved, <tt>false</tt> otherwise
+     */
+    protected boolean isPlacedholderResolved(String content, Options options) {
+        if (options.data(RESOLVED_PLACEHOLDERS) == null) {
+            options.data(RESOLVED_PLACEHOLDERS, new HashSet<String>());
+            return false;
+        }
+        return ((HashSet) options.data(RESOLVED_PLACEHOLDERS)).contains(content);
     }
 }

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/FillPlaceholderHelper.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/FillPlaceholderHelper.java
@@ -24,10 +24,10 @@ import org.wso2.carbon.uuf.renderablecreator.hbs.core.HbsRenderable;
 
 import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 
 public abstract class FillPlaceholderHelper<T> implements Helper<T> {
 
-    protected static final String RESOLVED_PLACEHOLDERS = "resolvedPlaceholders";
     private final Placeholder placeholder;
 
     protected FillPlaceholderHelper(Placeholder placeholder) {
@@ -48,19 +48,19 @@ public abstract class FillPlaceholderHelper<T> implements Helper<T> {
         return requestLookup.getPlaceholderContent(placeholder);
     }
 
-    /**
-     * Create a {@link HashSet} with the name {@code RESOLVED_PLACEHOLDERS} in handlebars options data if it's not
-     * there. Check whether the given content is already resolved.
-     *
-     * @param options handlebars options to get {@code RESOLVED_PLACEHOLDERS}
-     * @param content content to check for
-     * @return <tt>true</tt> if the placeholder is already resolved, <tt>false</tt> otherwise
-     */
-    protected boolean isPlacedholderResolved(String content, Options options) {
-        if (options.data(RESOLVED_PLACEHOLDERS) == null) {
-            options.data(RESOLVED_PLACEHOLDERS, new HashSet<String>());
+    protected String getResourceIdentifier(RequestLookup requestLookup, String relativePath) {
+        RequestLookup.RenderingFlowTracker tracker = requestLookup.tracker();
+        // unique resource identifier is calculated as fragment/component name:relativePath
+        String resourceIdentifier = tracker.isInFragment() ? tracker.getCurrentFragment().get().getName()
+                : tracker.getCurrentComponentName();
+        return resourceIdentifier + relativePath;
+    }
+
+    protected boolean isResourceAlreadyResolved(String resourceIdentifier, Options handlebarsOptions) {
+        if (handlebarsOptions.data(HbsRenderable.DATA_KEY_RESOLVED_RESOURCES) == null) {
+            handlebarsOptions.data(HbsRenderable.DATA_KEY_RESOLVED_RESOURCES, new HashSet<>());
             return false;
         }
-        return ((HashSet) options.data(RESOLVED_PLACEHOLDERS)).contains(content);
+        return ((Set) handlebarsOptions.data(HbsRenderable.DATA_KEY_RESOLVED_RESOURCES)).contains(resourceIdentifier);
     }
 }

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/CssHelper.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/CssHelper.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.uuf.renderablecreator.hbs.core.HbsRenderable;
 import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.FillPlaceholderHelper;
 
 import java.io.IOException;
+import java.util.HashSet;
 
 public class CssHelper extends FillPlaceholderHelper<String> {
 
@@ -33,6 +34,7 @@ public class CssHelper extends FillPlaceholderHelper<String> {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public CharSequence apply(String relativePath, Options options) throws IOException {
         if (relativePath == null) {
             throw new IllegalArgumentException("Relative path of a CSS file cannot be null.");
@@ -48,8 +50,14 @@ public class CssHelper extends FillPlaceholderHelper<String> {
             buffer.append(param);
         }
         buffer.append("\" rel=\"stylesheet\" type=\"text/css\" />\n");
+        String content = buffer.toString();
 
-        addToPlaceholder(buffer.toString(), options);
+        if (isPlacedholderResolved(content, options)) {
+            return "";
+        }
+
+        addToPlaceholder(content, options);
+        ((HashSet<String>) options.data(RESOLVED_PLACEHOLDERS)).add(content);
         return "";
     }
 }

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/CssHelper.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/CssHelper.java
@@ -23,7 +23,7 @@ import org.wso2.carbon.uuf.renderablecreator.hbs.core.HbsRenderable;
 import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.FillPlaceholderHelper;
 
 import java.io.IOException;
-import java.util.HashSet;
+import java.util.Set;
 
 public class CssHelper extends FillPlaceholderHelper<String> {
 
@@ -41,23 +41,25 @@ public class CssHelper extends FillPlaceholderHelper<String> {
 
         }
 
-        RequestLookup requestLookup = options.data(HbsRenderable.DATA_KEY_REQUEST_LOOKUP);
-        StringBuilder buffer = new StringBuilder("<link href=\"")
-                .append(requestLookup.getPublicUri())
-                .append('/')
-                .append(relativePath);
+        StringBuilder completeRelativePath = new StringBuilder(relativePath);
         for (Object param : options.params) {
-            buffer.append(param);
+            completeRelativePath.append(param);
         }
-        buffer.append("\" rel=\"stylesheet\" type=\"text/css\" />\n");
-        String content = buffer.toString();
 
-        if (isPlacedholderResolved(content, options)) {
+        RequestLookup requestLookup = options.data(HbsRenderable.DATA_KEY_REQUEST_LOOKUP);
+
+        String resourceIdentifier = getResourceIdentifier(requestLookup, completeRelativePath.toString());
+        if (isResourceAlreadyResolved(resourceIdentifier, options)) {
             return "";
         }
 
-        addToPlaceholder(content, options);
-        ((HashSet<String>) options.data(RESOLVED_PLACEHOLDERS)).add(content);
+        StringBuilder buffer = new StringBuilder("<link href=\"")
+                .append(requestLookup.getPublicUri())
+                .append('/')
+                .append(completeRelativePath);
+        buffer.append("\" rel=\"stylesheet\" type=\"text/css\" />\n");
+        addToPlaceholder(buffer.toString(), options);
+        ((Set) options.data(HbsRenderable.DATA_KEY_RESOLVED_RESOURCES)).add(resourceIdentifier);
         return "";
     }
 }

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/HeadJsHelper.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/HeadJsHelper.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.uuf.renderablecreator.hbs.core.HbsRenderable;
 import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.FillPlaceholderHelper;
 
 import java.io.IOException;
+import java.util.HashSet;
 
 public class HeadJsHelper extends FillPlaceholderHelper<String> {
 
@@ -37,6 +38,7 @@ public class HeadJsHelper extends FillPlaceholderHelper<String> {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public CharSequence apply(String relativePath, Options options) throws IOException {
         if (relativePath == null) {
             throw new IllegalArgumentException("Relative path of a JS file cannot be null.");
@@ -63,8 +65,14 @@ public class HeadJsHelper extends FillPlaceholderHelper<String> {
             buffer.append(" defer");
         }
         buffer.append(" type=\"text/javascript\"></script>\n");
+        String content = buffer.toString();
 
-        addToPlaceholder(buffer.toString(), options);
+        if (isPlacedholderResolved(content, options)) {
+            return "";
+        }
+
+        addToPlaceholder(content, options);
+        ((HashSet<String>) options.data(RESOLVED_PLACEHOLDERS)).add(content);
         return "";
     }
 }

--- a/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/handlebars/HbsHelperTest.java
+++ b/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/handlebars/HbsHelperTest.java
@@ -140,6 +140,17 @@ public class HbsHelperTest {
     }
 
     @Test
+    public void testCssWithDuplicatePlaceholders() {
+        RequestLookup requestLookup = createRequestLookup();
+        when(requestLookup.getPublicUri()).thenReturn("/myapp/public/component/base");
+        createRenderable("{{css \"css/my-styles.css\"}} {{css \"css/my-styles.css\"}}")
+                .render(null, createLookup(), requestLookup, createAPI());
+        String expected = "<link href=\"/myapp/public/component/base/css/my-styles.css\" rel=\"stylesheet\" " +
+                "type=\"text/css\" />\n";
+        Assert.assertEquals(requestLookup.getPlaceholderContent(Placeholder.css).get(), expected);
+    }
+
+    @Test
     public void testHeadJs() {
         RequestLookup requestLookup = createRequestLookup();
         when(requestLookup.getPublicUri()).thenReturn("/myapp/public/component/base");
@@ -162,6 +173,18 @@ public class HbsHelperTest {
         Assert.assertEquals(requestLookup.getPlaceholderContent(Placeholder.headJs).get(),
                             "<script src=\"/myapp/public/component/base/js/my-script.js\" type=\"text/javascript\">" +
                                     "</script>\n");
+    }
+
+    @Test
+    public void testHeadJsWithDuplicatePlaceholders() {
+        RequestLookup requestLookup = createRequestLookup();
+        when(requestLookup.getPublicUri()).thenReturn("/myapp/public/component/base");
+        createRenderable("{{headJs \"js/my-script.js\"}} {{headJs \"js/my-script.js\"}}")
+                .render(null, createLookup(), requestLookup, createAPI());
+
+        String expected = "<script src=\"/myapp/public/component/base/js/my-script.js\" type=\"text/javascript\">" +
+                "</script>\n";
+        Assert.assertEquals(requestLookup.getPlaceholderContent(Placeholder.headJs).get(), expected);
     }
 
     @Test

--- a/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/handlebars/HbsHelperTest.java
+++ b/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/handlebars/HbsHelperTest.java
@@ -33,12 +33,15 @@ import org.wso2.carbon.uuf.core.Page;
 import org.wso2.carbon.uuf.core.RequestLookup;
 import org.wso2.carbon.uuf.internal.core.UriPatten;
 import org.wso2.carbon.uuf.renderablecreator.hbs.core.HbsRenderable;
+import org.wso2.carbon.uuf.renderablecreator.hbs.impl.HbsFragmentRenderable;
 import org.wso2.carbon.uuf.renderablecreator.hbs.impl.HbsPageRenderable;
 import org.wso2.carbon.uuf.spi.HttpRequest;
+import org.wso2.carbon.uuf.spi.model.Model;
 
 import java.util.Collections;
 import java.util.Optional;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -66,6 +69,17 @@ public class HbsHelperTest {
         API api = mock(API.class);
         when(api.getSession()).thenReturn(Optional.empty());
         return api;
+    }
+
+    private static RequestLookup.RenderingFlowTracker createRenderingFlowTracker(boolean isInFragment) {
+        RequestLookup.RenderingFlowTracker tracker = mock(RequestLookup.RenderingFlowTracker.class);
+        if (isInFragment) {
+            when(tracker.isInFragment()).thenReturn(true);
+        } else {
+            when(tracker.isInPage()).thenReturn(true);
+            when(tracker.isInLayout()).thenReturn(true);
+        }
+        return tracker;
     }
 
     @Test
@@ -118,7 +132,11 @@ public class HbsHelperTest {
     public void testCss() {
         RequestLookup requestLookup = createRequestLookup();
         when(requestLookup.getPublicUri()).thenReturn("/myapp/public/component/base");
-        createRenderable("{{css \"css/my-styles.css\"}}").render(null, createLookup(), requestLookup, createAPI());
+        RequestLookup.RenderingFlowTracker tracker = createRenderingFlowTracker(false);
+        when(tracker.getCurrentComponentName()).thenReturn("test.component");
+        when(requestLookup.tracker()).thenReturn(tracker);
+        createRenderable("{{css \"css/my-styles.css\"}}{{css \"css/my-styles.css\"}}")
+                .render(null, createLookup(), requestLookup, createAPI());
         String expected = "<link href=\"/myapp/public/component/base/css/my-styles.css\" rel=\"stylesheet\" " +
                 "type=\"text/css\" />\n";
 
@@ -132,29 +150,25 @@ public class HbsHelperTest {
     public void testCssWithMultipleParameters() {
         RequestLookup requestLookup = createRequestLookup();
         when(requestLookup.getPublicUri()).thenReturn("/myapp/public/component/base");
-        createRenderable("{{css \"css/\" \"my-styles\" \".css\"}}").render(null, createLookup(), requestLookup,
-                                                                           createAPI());
+        RequestLookup.RenderingFlowTracker tracker = createRenderingFlowTracker(false);
+        when(tracker.getCurrentComponentName()).thenReturn("test.component");
+        when(requestLookup.tracker()).thenReturn(tracker);
+        createRenderable("{{css \"css/\" \"my-styles\" \".css\"}}{{css \"css/\" \"my-styles\" \".css\"}}")
+                .render(null, createLookup(), requestLookup, createAPI());
         Assert.assertEquals(requestLookup.getPlaceholderContent(Placeholder.css).get(),
                             "<link href=\"/myapp/public/component/base/css/my-styles.css\" rel=\"stylesheet\" " +
                                     "type=\"text/css\" />\n");
     }
 
     @Test
-    public void testCssWithDuplicatePlaceholders() {
-        RequestLookup requestLookup = createRequestLookup();
-        when(requestLookup.getPublicUri()).thenReturn("/myapp/public/component/base");
-        createRenderable("{{css \"css/my-styles.css\"}} {{css \"css/my-styles.css\"}}")
-                .render(null, createLookup(), requestLookup, createAPI());
-        String expected = "<link href=\"/myapp/public/component/base/css/my-styles.css\" rel=\"stylesheet\" " +
-                "type=\"text/css\" />\n";
-        Assert.assertEquals(requestLookup.getPlaceholderContent(Placeholder.css).get(), expected);
-    }
-
-    @Test
     public void testHeadJs() {
         RequestLookup requestLookup = createRequestLookup();
         when(requestLookup.getPublicUri()).thenReturn("/myapp/public/component/base");
-        createRenderable("{{headJs \"js/my-script.js\"}}").render(null, createLookup(), requestLookup, createAPI());
+        RequestLookup.RenderingFlowTracker tracker = createRenderingFlowTracker(false);
+        when(tracker.getCurrentComponentName()).thenReturn("test.component");
+        when(requestLookup.tracker()).thenReturn(tracker);
+        createRenderable("{{headJs \"js/my-script.js\"}}{{headJs \"js/my-script.js\"}}")
+                .render(null, createLookup(), requestLookup, createAPI());
         String expected = "<script src=\"/myapp/public/component/base/js/my-script.js\" type=\"text/javascript\">" +
                 "</script>\n";
 
@@ -168,30 +182,25 @@ public class HbsHelperTest {
     public void testHeadJsWithMultipleParameters() {
         RequestLookup requestLookup = createRequestLookup();
         when(requestLookup.getPublicUri()).thenReturn("/myapp/public/component/base");
-        createRenderable("{{headJs \"js/\" \"my-script\" \".js\"}}").render(null, createLookup(), requestLookup,
-                                                                            createAPI());
+        RequestLookup.RenderingFlowTracker tracker = createRenderingFlowTracker(false);
+        when(tracker.getCurrentComponentName()).thenReturn("test.component");
+        when(requestLookup.tracker()).thenReturn(tracker);
+        createRenderable("{{headJs \"js/\" \"my-script\" \".js\"}}{{headJs \"js/\" \"my-script\" \".js\"}}")
+                .render(null, createLookup(), requestLookup, createAPI());
         Assert.assertEquals(requestLookup.getPlaceholderContent(Placeholder.headJs).get(),
                             "<script src=\"/myapp/public/component/base/js/my-script.js\" type=\"text/javascript\">" +
                                     "</script>\n");
     }
 
     @Test
-    public void testHeadJsWithDuplicatePlaceholders() {
-        RequestLookup requestLookup = createRequestLookup();
-        when(requestLookup.getPublicUri()).thenReturn("/myapp/public/component/base");
-        createRenderable("{{headJs \"js/my-script.js\"}} {{headJs \"js/my-script.js\"}}")
-                .render(null, createLookup(), requestLookup, createAPI());
-
-        String expected = "<script src=\"/myapp/public/component/base/js/my-script.js\" type=\"text/javascript\">" +
-                "</script>\n";
-        Assert.assertEquals(requestLookup.getPlaceholderContent(Placeholder.headJs).get(), expected);
-    }
-
-    @Test
     public void testJs() {
         RequestLookup requestLookup = createRequestLookup();
         when(requestLookup.getPublicUri()).thenReturn("/myapp/public/component/base");
-        createRenderable("{{js \"js/bottom-script.js\"}}").render(null, createLookup(), requestLookup, createAPI());
+        RequestLookup.RenderingFlowTracker tracker = createRenderingFlowTracker(false);
+        when(tracker.getCurrentComponentName()).thenReturn("test.component");
+        when(requestLookup.tracker()).thenReturn(tracker);
+        createRenderable("{{js \"js/bottom-script.js\"}}{{js \"js/bottom-script.js\"}}")
+                .render(null, createLookup(), requestLookup, createAPI());
         String expected = "<script src=\"/myapp/public/component/base/js/bottom-script.js\" type=\"text/javascript\">" +
                 "</script>\n";
 
@@ -299,5 +308,30 @@ public class HbsHelperTest {
         String expected = "<script id=\"" + templateName + "\" type=\"text/x-handlebars-template\">\n" +
                 fragmentContent + "\n</script>";
         Assert.assertEquals(requestLookup.getPlaceholderContent(Placeholder.js).get(), expected);
+    }
+
+    @Test
+    public void testDuplicatedResources() {
+        RequestLookup requestLookup = createRequestLookup();
+        when(requestLookup.getPublicUri()).thenReturn("/myapp/public/component/base");
+        HbsRenderable fragmentRenderable = new HbsFragmentRenderable(
+                new StringTemplateSource("", "{{css \"css/my-styles.css\"}}{{headJs \"js/my-script.js\"}}"));
+        Lookup lookup = createLookup();
+        Fragment fragment = new Fragment("test.fragment", fragmentRenderable, false) {
+            @Override
+            public String render(Model model, Lookup lookup, RequestLookup requestLookup, API api) {
+                return fragmentRenderable.render(model, lookup, requestLookup, api);
+            }
+        };
+        when(lookup.getFragmentIn(any(), any())).thenReturn(Optional.of(fragment));
+        HbsRenderable pageRenderable = createRenderable("{{placeholder \"css\"}}{{placeholder \"headJs\"}}" +
+                "{{fragment \"test.fragment\"}}{{fragment \"test.fragment\"}}");
+        RequestLookup.RenderingFlowTracker tracker = createRenderingFlowTracker(true);
+        when(requestLookup.tracker()).thenReturn(tracker);
+        when(tracker.getCurrentFragment()).thenReturn(Optional.of(fragment));
+        String expected = "<link href=\"/myapp/public/component/base/css/my-styles.css\" rel=\"stylesheet\" " +
+                "type=\"text/css\" />\n<script src=\"/myapp/public/component/base/js/my-script.js\" " +
+                "type=\"text/javascript\"></script>\n";
+        Assert.assertEquals(pageRenderable.render(null, lookup, requestLookup, createAPI()), expected);
     }
 }


### PR DESCRIPTION
In `CssHelper` and `HeadJsHelper`, a HashSet in `com.github.jknack.handlebars.Options.data` is used to store the resolved placeholders. So a css or js resource placeholder will be resolved only if it is not resolved already. Hence we can avoid duplication of css and/or js resource entry in the final HTML even the same fragment (from which the css and js resources come from) is included more than once.

Resolves #83 