### PR TITLE
Implement API deployment capability for a component

### DIFF
--- a/components/uuf-core/pom.xml
+++ b/components/uuf-core/pom.xml
@@ -87,6 +87,10 @@
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.msf4j</groupId>
+            <artifactId>msf4j-core</artifactId>
+        </dependency>
         <!--Test-->
         <dependency>
             <groupId>org.testng</groupId>
@@ -112,6 +116,7 @@
                             org.wso2.carbon.kernel.startupresolver.*; version="${carbon.kernel.version.range}",
                             org.wso2.carbon.kernel.transports.*;version="${carbon.kernel.version.range}",
                             org.wso2.carbon.kernel.utils,
+                            org.wso2.msf4j;version="${msf4j.version}",
                             javax.naming,
                             javax.cache.*,
                             org.osgi.framework;version="${osgi.framework.import.version.range}",

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
@@ -210,12 +210,13 @@ public class AppCreator {
             try {
                 apiImplementation = classLoader.loadClass(className).newInstance();
             } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-                throw new UUFException("Error in deploying API " + className, e);
+                throw new UUFException("Cannot deploy REST API '" + className + "' for component '" +
+                        componentName + "'", e);
             }
             Dictionary<String, String> serviceProperties = new Hashtable<>();
             serviceProperties.put("contextPath", uri);
             classLoaderProvider.deployAPI(apiImplementation, serviceProperties);
-            LOGGER.info("Deployed API '{}' in component '{}' with the context path '{}'.",
+            LOGGER.info("Deployed REST API '{}' for component '{}' with context path '{}'.",
                     className, componentName, uri);
         }
     }

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
@@ -52,7 +52,6 @@ import org.wso2.carbon.uuf.internal.deployment.parser.ConfigurationParser;
 import org.wso2.carbon.uuf.internal.deployment.parser.DependencyTreeParser;
 import org.wso2.carbon.uuf.internal.util.NameUtils;
 import org.wso2.carbon.uuf.spi.RenderableCreator;
-import org.wso2.msf4j.Microservice;
 import org.yaml.snakeyaml.Yaml;
 
 import java.util.ArrayList;
@@ -213,12 +212,9 @@ public class AppCreator {
             } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
                 throw new UUFException("Error in deploying API " + className, e);
             }
-            if (!(apiImplementation instanceof Microservice)) {
-                throw new UUFException("API class " + apiImplementation + " doesn't implement Microservice interface");
-            }
             Dictionary<String, String> serviceProperties = new Hashtable<>();
             serviceProperties.put("contextPath", uri);
-            classLoaderProvider.deployAPI(Microservice.class, (Microservice) apiImplementation, serviceProperties);
+            classLoaderProvider.deployAPI(apiImplementation, serviceProperties);
             LOGGER.info("Deployed API '{}' in component '{}' with the context path '{}'.",
                     className, componentName, uri);
         }

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
@@ -219,7 +219,8 @@ public class AppCreator {
             Dictionary<String, String> serviceProperties = new Hashtable<>();
             serviceProperties.put("contextPath", uri);
             classLoaderProvider.deployAPI(Microservice.class, (Microservice) apiImplementation, serviceProperties);
-            LOGGER.info("Deployed API " + className + " with the context " + uri + " in component " + componentName);
+            LOGGER.info("Deployed API '{}' in component '{}' with the context path '{}'.",
+                    className, componentName, uri);
         }
     }
 

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/ClassLoaderProvider.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/ClassLoaderProvider.java
@@ -40,12 +40,10 @@ public interface ClassLoaderProvider {
     ClassLoader getClassLoader(String componentName, String componentVersion, ComponentReference componentReference);
 
     /**
-     * Deploys an API service.
+     * Deploys an API as a MSF4J service.
      *
-     * @param tClass     interface name
-     * @param object     service object which implements the interface
-     * @param properties service specific properties
-     * @param <T>        service type
+     * @param serviceImplementation service object which implements the interface
+     * @param properties            service specific properties
      */
-    <T> void deployAPI(Class<T> tClass, T object, Dictionary<String, ?> properties);
+    void deployAPI(Object serviceImplementation, Dictionary<String, ?> properties);
 }

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/ClassLoaderProvider.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/ClassLoaderProvider.java
@@ -20,6 +20,8 @@ package org.wso2.carbon.uuf.internal.deployment;
 
 import org.wso2.carbon.uuf.api.reference.ComponentReference;
 
+import java.util.Dictionary;
+
 /**
  * A provider that gives the class loader for a given component.
  *
@@ -36,4 +38,14 @@ public interface ClassLoaderProvider {
      * @return class loader for specified component
      */
     ClassLoader getClassLoader(String componentName, String componentVersion, ComponentReference componentReference);
+
+    /**
+     * Deploys an API service.
+     *
+     * @param tClass     interface name
+     * @param object     service object which implements the interface
+     * @param properties service specific properties
+     * @param <T>        service type
+     */
+    <T> void deployAPI(Class<T> tClass, T object, Dictionary<String, ?> properties);
 }

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/io/BundleClassLoaderProvider.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/io/BundleClassLoaderProvider.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Dictionary;
 import java.util.List;
 import java.util.Optional;
 import java.util.jar.Attributes;
@@ -65,6 +66,12 @@ public class BundleClassLoaderProvider implements ClassLoaderProvider {
         Bundle bundle = getBundle(componentName, componentVersion, componentReference);
         BundleWiring bundleWiring = bundle.adapt(BundleWiring.class);
         return bundleWiring.getClassLoader();
+    }
+
+    @Override
+    public <T> void deployAPI(Class<T> tClass, T object, Dictionary<String, ?> properties) {
+        BundleContext bundleContext = FrameworkUtil.getBundle(this.getClass()).getBundleContext();
+        bundleContext.registerService(tClass, object, properties);
     }
 
     /**

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/io/BundleClassLoaderProvider.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/io/BundleClassLoaderProvider.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.uuf.api.reference.FileReference;
 import org.wso2.carbon.uuf.exception.FileOperationException;
 import org.wso2.carbon.uuf.exception.UUFException;
 import org.wso2.carbon.uuf.internal.deployment.ClassLoaderProvider;
+import org.wso2.msf4j.Microservice;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -69,9 +70,13 @@ public class BundleClassLoaderProvider implements ClassLoaderProvider {
     }
 
     @Override
-    public <T> void deployAPI(Class<T> tClass, T object, Dictionary<String, ?> properties) {
+    public void deployAPI(Object serviceImplementation, Dictionary<String, ?> properties) {
+        if (!(serviceImplementation instanceof Microservice)) {
+            throw new UUFException("API class " + serviceImplementation.getClass().getName() +
+                    " doesn't implement Microservice interface");
+        }
         BundleContext bundleContext = FrameworkUtil.getBundle(this.getClass()).getBundleContext();
-        bundleContext.registerService(tClass, object, properties);
+        bundleContext.registerService(Microservice.class, (Microservice) serviceImplementation, properties);
     }
 
     /**

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/io/BundleClassLoaderProvider.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/io/BundleClassLoaderProvider.java
@@ -72,8 +72,8 @@ public class BundleClassLoaderProvider implements ClassLoaderProvider {
     @Override
     public void deployAPI(Object serviceImplementation, Dictionary<String, ?> properties) {
         if (!(serviceImplementation instanceof Microservice)) {
-            throw new UUFException("API class " + serviceImplementation.getClass().getName() +
-                    " doesn't implement Microservice interface");
+            throw new UUFException("Cannot deploy REST API '" + serviceImplementation.getClass().getName() +
+                    "' as a micro-service because it does not implement '" + Microservice.class.getName() + "'");
         }
         BundleContext bundleContext = FrameworkUtil.getBundle(this.getClass()).getBundleContext();
         bundleContext.registerService(Microservice.class, (Microservice) serviceImplementation, properties);

--- a/components/uuf-core/src/test/java/org/wso2/carbon/uuf/APITest.java
+++ b/components/uuf-core/src/test/java/org/wso2/carbon/uuf/APITest.java
@@ -1,0 +1,99 @@
+package org.wso2.carbon.uuf;
+
+/*
+ *  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.carbon.uuf.api.reference.AppReference;
+import org.wso2.carbon.uuf.api.reference.ComponentReference;
+import org.wso2.carbon.uuf.api.reference.FileReference;
+import org.wso2.carbon.uuf.internal.deployment.AppCreator;
+import org.wso2.carbon.uuf.internal.deployment.ClassLoaderProvider;
+import org.wso2.carbon.uuf.spi.RenderableCreator;
+
+import java.util.Dictionary;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * This test class contains test method(s) to test the API deployment capability feature of UUF.
+ */
+public class APITest {
+
+    @SuppressWarnings({"unchecked"})
+    @Test
+    public void testAPIContextPath() throws ClassNotFoundException {
+        String appContextpath = "/sample-app";
+        String apiClassName = "org.wso2.carbon.uuf.SampleAPI";
+        String apiURI = "/sample-api";
+
+        RenderableCreator renderableCreator = mock(RenderableCreator.class);
+        when(renderableCreator.getSupportedFileExtensions()).thenReturn(new HashSet());
+        Set<RenderableCreator> renderableCreators = new HashSet<>();
+        renderableCreators.add(renderableCreator);
+
+        FileReference dependencyTreeFileReference = mock(FileReference.class);
+        FileReference configFileReference = mock(FileReference.class);
+        FileReference manifestFileReference = mock(FileReference.class);
+        when(dependencyTreeFileReference.getContent()).thenReturn(
+                "artifactId: org.wso2.carbon.uuf.sample.sample-app.feature\n" +
+                        "version: 1.0.0-SNAPSHOT\n" +
+                        "contextPath: " + appContextpath);
+        when(manifestFileReference.getContent()).thenReturn(
+                "apis:\n" +
+                        "    - className: \"" + apiClassName + "\"\n" +
+                        "      uri: \"" + apiURI + "\"");
+        when(configFileReference.getContent()).thenReturn("appName: Sample Application");
+
+        ComponentReference componentReference = mock(ComponentReference.class);
+        when(componentReference.getLayouts(any())).thenReturn(Stream.empty());
+        when(componentReference.getFragments(any())).thenReturn(Stream.empty());
+        when(componentReference.getPages(any())).thenReturn(Stream.empty());
+        when(componentReference.getManifest()).thenReturn(Optional.of(manifestFileReference));
+
+        AppReference appReference = mock(AppReference.class);
+        when(appReference.getConfiguration()).thenReturn(configFileReference);
+        when(appReference.getDependencyTree()).thenReturn(dependencyTreeFileReference);
+        when(appReference.getThemeReferences()).thenReturn(Stream.empty());
+        when(appReference.getComponentReference(any())).thenReturn(componentReference);
+
+        ClassLoaderProvider classLoaderProvider = mock(ClassLoaderProvider.class);
+        ClassLoader classLoader = mock(ClassLoader.class);
+        when(classLoaderProvider.getClassLoader(any(), any(), any())).thenReturn(classLoader);
+        when(classLoader.loadClass(apiClassName)).thenReturn((Class) SampleAPI.class);
+
+        // This single element array is used to store the api context path
+        final String[] apiContextPath = new String[1];
+        doAnswer(invocation -> {
+            Dictionary<String, String> serviceProperties = (Dictionary<String, String>) invocation.getArguments()[2];
+            apiContextPath[0] = serviceProperties.get("contextPath");
+            return null;
+        }).when(classLoaderProvider).deployAPI(any(), any(), any());
+
+        AppCreator appCreator = new AppCreator(renderableCreators, classLoaderProvider);
+        appCreator.createApp(appReference, appContextpath);
+
+        String expectedApiContextPath = appContextpath + "/root/apis" + apiURI;
+        Assert.assertEquals(apiContextPath[0], expectedApiContextPath, "Calculated API context path is wrong.");
+    }
+
+}

--- a/components/uuf-core/src/test/java/org/wso2/carbon/uuf/APITest.java
+++ b/components/uuf-core/src/test/java/org/wso2/carbon/uuf/APITest.java
@@ -84,10 +84,10 @@ public class APITest {
         // This single element array is used to store the api context path
         final String[] apiContextPath = new String[1];
         doAnswer(invocation -> {
-            Dictionary<String, String> serviceProperties = (Dictionary<String, String>) invocation.getArguments()[2];
+            Dictionary<String, String> serviceProperties = (Dictionary<String, String>) invocation.getArguments()[1];
             apiContextPath[0] = serviceProperties.get("contextPath");
             return null;
-        }).when(classLoaderProvider).deployAPI(any(), any(), any());
+        }).when(classLoaderProvider).deployAPI(any(), any());
 
         AppCreator appCreator = new AppCreator(renderableCreators, classLoaderProvider);
         appCreator.createApp(appReference, appContextpath);

--- a/components/uuf-core/src/test/java/org/wso2/carbon/uuf/SampleAPI.java
+++ b/components/uuf-core/src/test/java/org/wso2/carbon/uuf/SampleAPI.java
@@ -1,0 +1,25 @@
+package org.wso2.carbon.uuf;
+
+import org.wso2.msf4j.Microservice;
+
+/*
+ *  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * This is a sample implementation of an MSF4J API that is used in APITest.
+ */
+public class SampleAPI implements Microservice {
+}

--- a/components/uuf-httpconnector-msf4j/pom.xml
+++ b/components/uuf-httpconnector-msf4j/pom.xml
@@ -78,6 +78,7 @@
                             <!--TODO: replace below line with above commented line after carbon-messaging fix export version issue.-->
                             org.wso2.carbon.messaging;version="1.0.5",
                             org.wso2.msf4j.*,
+                            org.osgi.framework;version="${osgi.framework.import.version.range}",
                             javax.ws.rs.*,
                             io.netty.handler.*,
                             org.osgi.service.component.annotations.*,

--- a/pom.xml
+++ b/pom.xml
@@ -378,6 +378,54 @@
                 <version>${equinox.osgi.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.apache.servicemix.bundles</groupId>
+                <artifactId>org.apache.servicemix.bundles.commons-beanutils</artifactId>
+                <version>${beanutils.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-buffer</artifactId>
+                <version>${netty.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-common</artifactId>
+                <version>${netty.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>${netty.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport</artifactId>
+                <version>${netty.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec</artifactId>
+                <version>${netty.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http</artifactId>
+                <version>${netty.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.lmax</groupId>
+                <artifactId>disruptor</artifactId>
+                <version>${disruptor.orbit.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -522,6 +570,9 @@
         <ow2.jta.spec.version>1.0.12</ow2.jta.spec.version>
         <osgi.service.tracker.package.import.version.range>[1.5.1, 2.0.0)
         </osgi.service.tracker.package.import.version.range>
+        <beanutils.version>1.8.3_2</beanutils.version>
+        <netty.version>4.0.30.Final</netty.version>
+        <disruptor.orbit.version>3.3.2.wso2v1</disruptor.orbit.version>
 
         <!-- Source and target Java version -->
         <wso2.maven.compiler.source>1.8</wso2.maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -418,7 +418,7 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
                 <version>${netty.version}</version>
-                <scope>test</scope>
+                <!--<scope>test</scope>-->
             </dependency>
             <dependency>
                 <groupId>org.wso2.lmax</groupId>

--- a/samples/apps/org.wso2.carbon.uuf.sample.pets-store/pom.xml
+++ b/samples/apps/org.wso2.carbon.uuf.sample.pets-store/pom.xml
@@ -77,6 +77,11 @@
             <artifactId>org.wso2.carbon.uuf.sample.simple-auth.bundle</artifactId>
             <version>${carbon.uuf.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.uuf.sample</groupId>
+            <artifactId>org.wso2.carbon.uuf.sample.api</artifactId>
+            <version>${carbon.uuf.version}</version>
+        </dependency>
     </dependencies>
 
 
@@ -96,7 +101,10 @@
                         </goals>
                         <configuration>
                             <instructions>
-                                <Import-Package>org.wso2.carbon.uuf.sample.simpleauth.bundle</Import-Package>
+                                <Import-Package>
+                                    org.wso2.carbon.uuf.sample.simpleauth.bundle,
+                                    org.wso2.carbon.uuf.sample.api
+                                </Import-Package>
                             </instructions>
                             <!--All backend dependencies should be specified here-->
                             <bundles>
@@ -106,6 +114,10 @@
                                 </bundle>
                                 <bundle>
                                     <symbolicName>org.wso2.carbon.uuf.sample.simple-auth.bundle</symbolicName>
+                                    <version>${carbon.uuf.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>org.wso2.carbon.uuf.sample.api</symbolicName>
                                     <version>${carbon.uuf.version}</version>
                                 </bundle>
                             </bundles>

--- a/samples/apps/org.wso2.carbon.uuf.sample.pets-store/src/main/component.yaml
+++ b/samples/apps/org.wso2.carbon.uuf.sample.pets-store/src/main/component.yaml
@@ -2,8 +2,9 @@
 # example entry:
 #    - className: "org.wso2.carbon.uuf.sample.pets-store.PetsStoreMicroservice"
 #      uri: "/pets/"
-apis: []
-
+apis:
+    - className: "org.wso2.carbon.uuf.sample.api.HelloService"
+      uri: "/hello-service/"
 # Binding fragments into zones.
 # Modes:
 #   prepend - pushes the specified fragments into the beginning of the existing pushed content of the zone

--- a/samples/osgi-services/org.wso2.carbon.uuf.sample.api/pom.xml
+++ b/samples/osgi-services/org.wso2.carbon.uuf.sample.api/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2016, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>org.wso2.carbon.uuf.sample.api</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+
+    <name>WSO2 UUF Sample - Hello Service API</name>
+    <description>This bundle contains the implementation of the Hello Serivce sample API.</description>
+    <url>http://wso2.org</url>
+
+    <parent>
+        <groupId>org.wso2.carbon.uuf.sample</groupId>
+        <artifactId>sample-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.msf4j</groupId>
+            <artifactId>msf4j-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                            org.wso2.carbon.uuf.sample.api.*;version="${version}"
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/samples/osgi-services/org.wso2.carbon.uuf.sample.api/src/main/java/org/wso2/carbon/uuf/sample/api/HelloService.java
+++ b/samples/osgi-services/org.wso2.carbon.uuf.sample.api/src/main/java/org/wso2/carbon/uuf/sample/api/HelloService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.uuf.sample.api;
+
+import org.wso2.msf4j.Microservice;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * Hello service sample API.
+ */
+public class HelloService implements Microservice {
+
+    @GET
+    @Path("/name")
+    public String getName() {
+        return "Hey!, this is the /name resource of the Hello Service sample API.";
+    }
+}

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -39,6 +39,7 @@
     <modules>
         <module>osgi-services/org.wso2.carbon.uuf.sample.pets-store.bundle</module>
         <module>osgi-services/org.wso2.carbon.uuf.sample.simple-auth.bundle</module>
+        <module>osgi-services/org.wso2.carbon.uuf.sample.api</module>
         <module>themes/org.wso2.carbon.uuf.sample.theme.default</module>
         <module>themes/org.wso2.carbon.uuf.sample.theme.blue</module>
         <module>themes/org.wso2.carbon.uuf.sample.theme.green</module>

--- a/tests/osgi-tests/pom.xml
+++ b/tests/osgi-tests/pom.xml
@@ -215,6 +215,52 @@
             <groupId>commons-io.wso2</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+        <!-- MSF4J -->
+        <dependency>
+            <groupId>org.wso2.msf4j</groupId>
+            <artifactId>msf4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.commons-beanutils</artifactId>
+            <version>1.8.3_2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.transport</groupId>
+            <artifactId>org.wso2.carbon.transport.http.netty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.messaging</groupId>
+            <artifactId>org.wso2.carbon.messaging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.lmax</groupId>
+            <artifactId>disruptor</artifactId>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/tests/osgi-tests/src/test/java/org/wso2/carbon/uuf/osgi/OSGiServicesTest.java
+++ b/tests/osgi-tests/src/test/java/org/wso2/carbon/uuf/osgi/OSGiServicesTest.java
@@ -75,7 +75,20 @@ public class OSGiServicesTest {
                 getBundleOption("org.wso2.carbon.uuf.core", "org.wso2.carbon.uuf"),
                 getBundleOption("org.wso2.carbon.uuf.renderablecreator.html", "org.wso2.carbon.uuf"),
                 getBundleOption("org.wso2.carbon.uuf.tests.dummy-http-connector", "org.wso2.carbon.uuf.tests"),
-                getBundleOption("org.wso2.carbon.uuf.sample.pets-store.bundle", "org.wso2.carbon.uuf.sample")
+                getBundleOption("org.wso2.carbon.uuf.sample.pets-store.bundle", "org.wso2.carbon.uuf.sample"),
+                // MSF4J
+                getBundleOption("msf4j-core", "org.wso2.msf4j"),
+                getBundleOption("org.apache.servicemix.bundles.commons-beanutils", "org.apache.servicemix.bundles"),
+                getBundleOption("javax.ws.rs-api", "javax.ws.rs"),
+                getBundleOption("netty-buffer", "io.netty"),
+                getBundleOption("netty-common", "io.netty"),
+                getBundleOption("netty-handler", "io.netty"),
+                getBundleOption("netty-transport", "io.netty"),
+                getBundleOption("netty-codec", "io.netty"),
+                getBundleOption("netty-codec-http", "io.netty"),
+                getBundleOption("disruptor", "org.wso2.lmax"),
+                getBundleOption("org.wso2.carbon.transport.http.netty", "org.wso2.carbon.transport"),
+                getBundleOption("org.wso2.carbon.messaging", "org.wso2.carbon.messaging")
         );
         return OSGiTestUtils.getDefaultPaxOptions(options);
     }


### PR DESCRIPTION
With this improvement, component developers can develop component related APIs and get them deployed with the application deployment.

### Developing an API
The developer can write the API implementing `org.wso2.msf4j.Microservice` interface. Following is a sample API implementation,

```
package org.wso2.carbon.uuf.sample.api;

import org.wso2.msf4j.Microservice;

import javax.ws.rs.GET;
import javax.ws.rs.Path;

public class HelloService implements Microservice {

    @GET
    @Path("/name")
    public String getName() {
        return "Hey!, this is the /name resource of the Hello Service sample API.";
    }
}

```

### Configuring the API in the component
API configuration is done via the `apis` section in the component manifest file (`component.yaml`). The api class name and the uri for each API can be defined as a list in the component manifest file. Following is a snippet of the component manifest  of the pets-store sample application,

```
apis:
    - className: "org.wso2.carbon.uuf.sample.api.HelloService"
      uri: "/hello-service/"
```

### How the API context path is calculated
APIs although bound to a component, are deployed at application deployment. Since the components reside inside an application, application context path is considered when calculating the context path of the API.

API context path is calculated as follows,
`application context path/component context path/apis/api uri`

### Hello Service sample API
A simple API called Hello Service is implemented as a sample and is deployed with the pets-store sample. This API has a single resource `/name` and can be invoked via `https://localhost:9292/pets-store/root/apis/hello-service/name`