### PR TITLE
add mandatory default security headers

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/RequestDispatcher.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/RequestDispatcher.java
@@ -88,8 +88,9 @@ public class RequestDispatcher {
             if (request.isFragmentRequest()) {
                 html = app.renderFragment(request, response);
             } else {
-                // Request for a page.
+                // Set default mandatory http headers for security purpose
                 setDefaultSecurityHeaders(response);
+                // Request for a page.
                 html = app.renderPage(request, response);
             }
             response.setContent(STATUS_OK, html, CONTENT_TYPE_TEXT_HTML);
@@ -117,6 +118,11 @@ public class RequestDispatcher {
         staticResolver.serveDefaultFavicon(request, response);
     }
 
+    /**
+     * Sets some default and mandatory security related headers to the response path.
+     *
+     * @param httpResponse the http response instance used with setting the headers.
+     */
     private void setDefaultSecurityHeaders(HttpResponse httpResponse) {
         httpResponse.setHeader(HEADER_X_CONTENT_TYPE_OPTIONS, "nosniff");
         httpResponse.setHeader(HEADER_X_XSS_PROTECTION, "1; mode=block");

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/RequestDispatcher.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/RequestDispatcher.java
@@ -85,11 +85,11 @@ public class RequestDispatcher {
     private void servePageOrFragment(App app, HttpRequest request, HttpResponse response) {
         try {
             String html;
+            // set default mandatory http headers for security purpose
+            setDefaultSecurityHeaders(response);
             if (request.isFragmentRequest()) {
                 html = app.renderFragment(request, response);
             } else {
-                // Set default mandatory http headers for security purpose
-                setDefaultSecurityHeaders(response);
                 // Request for a page.
                 html = app.renderPage(request, response);
             }

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/RequestDispatcher.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/RequestDispatcher.java
@@ -30,7 +30,12 @@ import org.wso2.carbon.uuf.spi.HttpRequest;
 import org.wso2.carbon.uuf.spi.HttpResponse;
 
 import static org.wso2.carbon.uuf.spi.HttpResponse.CONTENT_TYPE_TEXT_HTML;
+import static org.wso2.carbon.uuf.spi.HttpResponse.HEADER_CACHE_CONTROL;
+import static org.wso2.carbon.uuf.spi.HttpResponse.HEADER_EXPIRES;
 import static org.wso2.carbon.uuf.spi.HttpResponse.HEADER_LOCATION;
+import static org.wso2.carbon.uuf.spi.HttpResponse.HEADER_PRAGMA;
+import static org.wso2.carbon.uuf.spi.HttpResponse.HEADER_X_CONTENT_TYPE_OPTIONS;
+import static org.wso2.carbon.uuf.spi.HttpResponse.HEADER_X_XSS_PROTECTION;
 import static org.wso2.carbon.uuf.spi.HttpResponse.STATUS_FOUND;
 import static org.wso2.carbon.uuf.spi.HttpResponse.STATUS_INTERNAL_SERVER_ERROR;
 import static org.wso2.carbon.uuf.spi.HttpResponse.STATUS_OK;
@@ -84,6 +89,7 @@ public class RequestDispatcher {
                 html = app.renderFragment(request, response);
             } else {
                 // Request for a page.
+                setDefaultSecurityHeaders(response);
                 html = app.renderPage(request, response);
             }
             response.setContent(STATUS_OK, html, CONTENT_TYPE_TEXT_HTML);
@@ -109,5 +115,13 @@ public class RequestDispatcher {
 
     public void serveDefaultFavicon(HttpRequest request, HttpResponse response) {
         staticResolver.serveDefaultFavicon(request, response);
+    }
+
+    private void setDefaultSecurityHeaders(HttpResponse httpResponse) {
+        httpResponse.setHeader(HEADER_X_CONTENT_TYPE_OPTIONS, "nosniff");
+        httpResponse.setHeader(HEADER_X_XSS_PROTECTION, "1; mode=block");
+        httpResponse.setHeader(HEADER_CACHE_CONTROL, "no-store, no-cache, must-revalidate, private");
+        httpResponse.setHeader(HEADER_EXPIRES, "0");
+        httpResponse.setHeader(HEADER_PRAGMA, "no-cache");
     }
 }

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/io/StaticResolver.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/io/StaticResolver.java
@@ -53,6 +53,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import static org.wso2.carbon.uuf.api.reference.ComponentReference.DIR_NAME_FRAGMENTS;
 import static org.wso2.carbon.uuf.spi.HttpResponse.CONTENT_TYPE_IMAGE_PNG;
 import static org.wso2.carbon.uuf.spi.HttpResponse.CONTENT_TYPE_WILDCARD;
+import static org.wso2.carbon.uuf.spi.HttpResponse.HEADER_CACHE_CONTROL;
 import static org.wso2.carbon.uuf.spi.HttpResponse.STATUS_BAD_REQUEST;
 import static org.wso2.carbon.uuf.spi.HttpResponse.STATUS_INTERNAL_SERVER_ERROR;
 import static org.wso2.carbon.uuf.spi.HttpResponse.STATUS_NOT_FOUND;
@@ -296,7 +297,7 @@ public class StaticResolver {
 
     private void setCacheHeaders(ZonedDateTime lastModifiedDate, HttpResponse response) {
         response.setHeader("Last-Modified", HTTP_DATE_FORMATTER.format(lastModifiedDate));
-        response.setHeader("Cache-Control", "public,max-age=2592000");
+        response.setHeader(HEADER_CACHE_CONTROL, "public,max-age=2592000");
     }
 
     private String getContentType(HttpRequest request, Path resource) {

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/io/StaticResolver.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/io/StaticResolver.java
@@ -54,6 +54,7 @@ import static org.wso2.carbon.uuf.api.reference.ComponentReference.DIR_NAME_FRAG
 import static org.wso2.carbon.uuf.spi.HttpResponse.CONTENT_TYPE_IMAGE_PNG;
 import static org.wso2.carbon.uuf.spi.HttpResponse.CONTENT_TYPE_WILDCARD;
 import static org.wso2.carbon.uuf.spi.HttpResponse.HEADER_CACHE_CONTROL;
+import static org.wso2.carbon.uuf.spi.HttpResponse.HEADER_LAST_MODIFIED;
 import static org.wso2.carbon.uuf.spi.HttpResponse.STATUS_BAD_REQUEST;
 import static org.wso2.carbon.uuf.spi.HttpResponse.STATUS_INTERNAL_SERVER_ERROR;
 import static org.wso2.carbon.uuf.spi.HttpResponse.STATUS_NOT_FOUND;
@@ -296,7 +297,7 @@ public class StaticResolver {
     }
 
     private void setCacheHeaders(ZonedDateTime lastModifiedDate, HttpResponse response) {
-        response.setHeader("Last-Modified", HTTP_DATE_FORMATTER.format(lastModifiedDate));
+        response.setHeader(HEADER_LAST_MODIFIED, HTTP_DATE_FORMATTER.format(lastModifiedDate));
         response.setHeader(HEADER_CACHE_CONTROL, "public,max-age=2592000");
     }
 

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/spi/HttpResponse.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/spi/HttpResponse.java
@@ -45,6 +45,7 @@ public interface HttpResponse {
     String HEADER_X_CONTENT_TYPE_OPTIONS = "X-Content-Type-Options";
     String HEADER_X_XSS_PROTECTION = "X-XSS-Protection";
     String HEADER_CACHE_CONTROL = "Cache-Control";
+    String HEADER_LAST_MODIFIED = "Last-Modified";
     String HEADER_EXPIRES = "Expires";
     String HEADER_PRAGMA = "Pragma";
 

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/spi/HttpResponse.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/spi/HttpResponse.java
@@ -42,6 +42,11 @@ public interface HttpResponse {
     String CONTENT_TYPE_APPLICATION_JSON = "application/json";
 
     String HEADER_LOCATION = "Location";
+    String HEADER_X_CONTENT_TYPE_OPTIONS = "X-Content-Type-Options";
+    String HEADER_X_XSS_PROTECTION = "X-XSS-Protection";
+    String HEADER_CACHE_CONTROL = "Cache-Control";
+    String HEADER_EXPIRES = "Expires";
+    String HEADER_PRAGMA = "Pragma";
 
     void setStatus(int statusCode);
 


### PR DESCRIPTION
The following headers and the header values are added to all dynamic content response path (request for pages). This fixes #93

General Security Headers (applicable to all requests by default)
- **X-Content-Type-Options : nosniff**
- **X-XSS-Protection : 1; mode=block**

Cache Control Headers (applicable for all dynamic resources)
- **Cache-Control : no-store, no-cache, must-revalidate, private**
- **Expires : 0**
- **Pragma : no-cache**