### PR TITLE
Adding HTML comments to mark zones in the DOM

### DIFF
--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/DefineZoneHelper.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/DefineZoneHelper.java
@@ -42,6 +42,7 @@ public class DefineZoneHelper implements Helper<String> {
         Lookup lookup = options.data(HbsRenderable.DATA_KEY_LOOKUP);
         RequestLookup requestLookup = options.data(HbsRenderable.DATA_KEY_REQUEST_LOOKUP);
         StringBuilder buffer = new StringBuilder();
+        buffer.append("<!--[UUF-ZONE]{\"name\": \"").append(zoneName).append("\",\"position\": \"start\"}-->\n");
 
         List<Fragment> bindings = lookup.getBindings(requestLookup.tracker().getCurrentComponentName(), zoneName);
         if (!bindings.isEmpty()) {
@@ -52,6 +53,7 @@ public class DefineZoneHelper implements Helper<String> {
         }
 
         requestLookup.getZoneContent(zoneName).ifPresent(buffer::append);
+        buffer.append("<!--[UUF-ZONE]{\"name\": \"").append(zoneName).append("\",\"position\": \"end\"}-->\n");
         return new Handlebars.SafeString(buffer.toString());
     }
 }

--- a/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/handlebars/HbsRenderableTest.java
+++ b/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/handlebars/HbsRenderableTest.java
@@ -166,7 +166,9 @@ public class HbsRenderableTest {
         when(lookup.getBindings(any(), eq("test-zone"))).thenReturn(ImmutableList.of(pushedFragment));
 
         String output = pageRenderable.render(createModel(), lookup, createRequestLookup(), createAPI());
-        Assert.assertEquals(output, "X fragment content Y");
+        Assert.assertEquals(output, "X <!--[UUF-ZONE]{\"name\": \"test-zone\",\"position\": \"start\"}-->\n" +
+                "fragment content<!--[UUF-ZONE]{\"name\": \"test-zone\",\"position\": \"end\"}-->\n" +
+                " Y");
     }
 
     @Test
@@ -178,6 +180,8 @@ public class HbsRenderableTest {
         when(requestLookup.getZoneContent("test-zone")).thenReturn(Optional.of("zone content"));
 
         String output = pageRenderable.render(createModel(), lookup, requestLookup, createAPI());
-        Assert.assertEquals(output, "X zone content Y");
+        Assert.assertEquals(output, "X <!--[UUF-ZONE]{\"name\": \"test-zone\",\"position\": \"start\"}-->\n" +
+                "zone content<!--[UUF-ZONE]{\"name\": \"test-zone\",\"position\": \"end\"}-->\n" +
+                " Y");
     }
 }


### PR DESCRIPTION
This PR will add HTML comments to the final rendered HTML to mark the start and end of zones.
e.g.
```html
<!-- [UUF-ZONE]{zone: "footer", position: "start"} -->
     zone's content goes here...
<!-- [UUF-ZONE]{zone: "footer", position: "end"} -->
```

