### PR TITLE
Remove apiNote javadoc annotations

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/parser/AppConfig.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/parser/AppConfig.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 /**
  * Bean class that represents the app's config file of an UUF App.
  *
- * @apiNote Getters and setters of this class should match with getters and setters in
+ * Getters and setters of this class should match with getters and setters in
  * org.wso2.carbon.uuf.maven.bean.AppConfig class.
  * @since 1.0.0
  */

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/parser/ComponentConfig.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/parser/ComponentConfig.java
@@ -27,7 +27,7 @@ import java.util.Map;
 /**
  * Bean class that represents configurations of an UUF Component.
  *
- * @apiNote Getters and setters of this class should match with getters and setters in
+ * Getters and setters of this class should match with getters and setters in
  * org.wso2.carbon.uuf.maven.bean.ComponentConfig class.
  * @since 1.0.0
  */

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/parser/ThemeConfig.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/parser/ThemeConfig.java
@@ -24,7 +24,7 @@ import java.util.List;
 /**
  * Bean class that represents the theme's config file of an UUF Theme.
  *
- * @apiNote Getters and setters of this class should match with getters and setters in
+ * Getters and setters of this class should match with getters and setters in
  * org.wso2.carbon.uuf.maven.bean.ThemeConfig class.
  * @since 1.0.0
  */


### PR DESCRIPTION
This is removed because javadoc plugin fails to identify these.

https://github.com/sdl/oss-parent/issues/2