### PR TITLE
Fix fragment not found issue in bindings

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
@@ -228,7 +228,8 @@ public class AppCreator {
             }
             List<Fragment> fragments = new ArrayList<>(entry.getFragments().size());
             for (String fragmentName : entry.getFragments()) {
-                Fragment fragment = availableFragments.get(fragmentName);
+                Fragment fragment = availableFragments.get(NameUtils.getFullyQualifiedName(componentName,
+                                                                                           fragmentName));
                 if (fragment == null) {
                     throw new IllegalArgumentException(
                             "Fragment '" + fragmentName + "' given in the binding entry '" + entry +


### PR DESCRIPTION
This will fix fragment not found issue which occurs when we don't use the fragment
fully qualified name.

Resolves #149 