### PR TITLE
Change LoggerObject to print stack trace

### DIFF
--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/LoggerObject.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/LoggerObject.java
@@ -85,7 +85,7 @@ public class LoggerObject {
             stringWriter.write(getLogMessage(obj));
 
             PrintWriter printWriter = new PrintWriter(stringWriter);
-            EmptyException exception = new EmptyException();
+            CustomException exception = new CustomException();
             // Ignore the 0th element and print the stack trace from the 1st index to the printWriter.
             exception.printStackTrace(printWriter, 1);
             logger.error(stringWriter.toString());
@@ -173,7 +173,7 @@ public class LoggerObject {
     /**
      * Uses to get the modified stack trace.
      */
-    private static class EmptyException extends Exception {
+    private static class CustomException extends Exception {
 
         void printStackTrace(PrintWriter printWriter, int startIndex) {
             StackTraceElement[] stackTrace = getStackTrace();

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/LoggerObject.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/LoggerObject.java
@@ -86,9 +86,9 @@ public class LoggerObject {
             stringWriter.write(getLogMessage(obj));
 
             PrintWriter printWriter = new PrintWriter(stringWriter);
-            StackTracePrinter exception = new StackTracePrinter();
+            StackTracePrinter stackTracePrinter = new StackTracePrinter();
             // Ignore the 0th element and print the stack trace from the 1st index to the printWriter.
-            exception.printStackTrace(printWriter, 1);
+            stackTracePrinter.printStackTrace(printWriter, 1);
             logger.error(stringWriter.toString());
         }
     }

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/LoggerObject.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/LoggerObject.java
@@ -176,10 +176,5 @@ public class LoggerObject {
             this.setStackTrace(modifiedStackTrace);
             this.printStackTrace(printWriter);
         }
-
-        @Override
-        public String toString() {
-            return "";
-        }
     }
 }

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/LoggerObject.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/LoggerObject.java
@@ -171,10 +171,18 @@ public class LoggerObject {
     }
 
     /**
-     * Uses to get the modified stack trace.
+     * Uses to get a modified stack trace.
+     *
+     * @since 1.0.0
      */
     private static class CustomException extends Exception {
 
+        /**
+         * Properly formats and prints the stack trace to the given {@link PrintWriter} starting from the  given index.
+         *
+         * @param printWriter which uses to write the stack trace
+         * @param startIndex  start index of the stack trace to be printed
+         */
         void printStackTrace(PrintWriter printWriter, int startIndex) {
             StackTraceElement[] stackTrace = getStackTrace();
             StackTraceElement[] modifiedStackTrace = new StackTraceElement[stackTrace.length - 1];

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/LoggerObject.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/LoggerObject.java
@@ -86,7 +86,7 @@ public class LoggerObject {
             stringWriter.write(getLogMessage(obj));
 
             PrintWriter printWriter = new PrintWriter(stringWriter);
-            CustomException exception = new CustomException();
+            StackTracePrinter exception = new StackTracePrinter();
             // Ignore the 0th element and print the stack trace from the 1st index to the printWriter.
             exception.printStackTrace(printWriter, 1);
             logger.error(stringWriter.toString());
@@ -176,7 +176,7 @@ public class LoggerObject {
      *
      * @since 1.0.0
      */
-    private static class CustomException extends Exception {
+    private static class StackTracePrinter extends Exception {
 
         /**
          * Properly formats and prints the stack trace to the given {@link PrintWriter} starting from the  given index.

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/LoggerObject.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/LoggerObject.java
@@ -81,11 +81,14 @@ public class LoggerObject {
             logger.error(message, (Throwable) obj);
         } else {
             StringWriter stringWriter = new StringWriter();
+            stringWriter.write(message + " ");
+            stringWriter.write(getLogMessage(obj));
+
             PrintWriter printWriter = new PrintWriter(stringWriter);
             EmptyException exception = new EmptyException();
-            // Ignore the 0th element and print the stack trace from the 1st index
+            // Ignore the 0th element and print the stack trace from the 1st index to the printWriter.
             exception.printStackTrace(printWriter, 1);
-            logger.error(message + " " + getLogMessage(obj) + stringWriter.toString());
+            logger.error(stringWriter.toString());
         }
     }
 
@@ -167,6 +170,9 @@ public class LoggerObject {
                 "function(obj)}";
     }
 
+    /**
+     * Uses to get the modified stack trace.
+     */
     private static class EmptyException extends Exception {
 
         void printStackTrace(PrintWriter printWriter, int startIndex) {

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/LoggerObject.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/LoggerObject.java
@@ -168,7 +168,7 @@ public class LoggerObject {
     @Override
     public String toString() {
         return "{info: function(obj), debug: function(obj), trace: function(obj), warn: function(obj), error: " +
-                "function(obj)}";
+                "function(obj), error: function(message, obj)}";
     }
 
     /**

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/LoggerObject.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/LoggerObject.java
@@ -81,7 +81,8 @@ public class LoggerObject {
             logger.error(message, (Throwable) obj);
         } else {
             StringWriter stringWriter = new StringWriter();
-            stringWriter.write(message + " ");
+            stringWriter.write(message);
+            stringWriter.write(" ");
             stringWriter.write(getLogMessage(obj));
 
             PrintWriter printWriter = new PrintWriter(stringWriter);


### PR DESCRIPTION
Resolves #108 

This will also add a new private static class **CustomException** which will be used to modify and get the stack trace of the error.