### PR TITLE
Fixing internationalization not working properly in Safari browser

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/api/config/I18nResources.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/api/config/I18nResources.java
@@ -39,6 +39,9 @@ public class I18nResources {
      * @param i18n     properties
      */
     public void addI18nResource(String language, Properties i18n) {
+        // Convert the language key to lower case before adding to the map. This is done because various browsers
+        // send the locale in different formats.
+        language = language.toLowerCase();
         Properties i18nResource = this.i18nResources.get(language);
         if (i18nResource == null) {
             this.i18nResources.put(language, i18n);

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/api/config/I18nResources.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/api/config/I18nResources.java
@@ -18,10 +18,10 @@
 
 package org.wso2.carbon.uuf.api.config;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 /**
  * Holds the i18n language resources of an UUF App.
@@ -30,7 +30,7 @@ import java.util.Set;
  */
 public class I18nResources {
 
-    private final Map<String, Properties> i18nResources = new HashMap<>();
+    private final SortedMap<String, Properties> i18nResources = new TreeMap<>();
 
     /**
      * Adds the given language.

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/I18nHelper.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/I18nHelper.java
@@ -27,7 +27,7 @@ import java.util.Properties;
 
 public class I18nHelper implements Helper<String> {
 
-    public static final String HELPER_NAME = "t";
+    public static final String HELPER_NAME = "i18n";
     private static final String DEFAULT_LOCALE = "en_US";
     private static final String LOCALE_HEADER = "Accept-Language";
     private static final String LOCALE = "locale";

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/I18nHelper.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/I18nHelper.java
@@ -31,6 +31,7 @@ public class I18nHelper implements Helper<String> {
     private static final String DEFAULT_LOCALE = "en-us";
     private static final String LOCALE_HEADER = "Accept-Language";
     private static final String LOCALE = "locale";
+    private static final String CURRENT_LOCALE = "CURRENT_LOCALE";
 
     @Override
     public CharSequence apply(String key, Options options) throws IOException {
@@ -40,28 +41,31 @@ public class I18nHelper implements Helper<String> {
 
         RequestLookup requestLookup = options.data(HbsRenderable.DATA_KEY_REQUEST_LOOKUP);
         Lookup lookup = options.data(HbsRenderable.DATA_KEY_LOOKUP);
-        Object localParam = options.hash.get(LOCALE);
-        Object localeRequest;
-        String currentLocale;
 
-        if (localParam != null) {
-            currentLocale = localParam.toString();
-        } else if ((localeRequest = requestLookup.getRequest().getHeaders().get(LOCALE_HEADER)) != null) {
-            // example: en,en-US;q=0.7,en-AU;q=0.3
-            // https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4
-            String locale = localeRequest.toString().split(",")[0].replace("-", "_");
-            if (locale.contains("_")) {
-                currentLocale = locale;
-            } else {
+        // Check whether the current locale is already available in the options.
+        String currentLocale = options.data(CURRENT_LOCALE);
+        // If not available, get the current locale.
+        if (currentLocale == null) {
+            Object localeHeaderValue;
+            Object localeParam = options.hash.get(LOCALE);
+            if (localeParam != null) {
+                currentLocale = localeParam.toString();
+            } else if ((localeHeaderValue = requestLookup.getRequest().getHeaders().get(LOCALE_HEADER)) != null) {
+                // example: en,en-us;q=0.7, en-au;q=0.3
+                // https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4
+                // Change the locale value to lower case because we store the language keys in lower case.
+                String locale = localeHeaderValue.toString().toLowerCase().split(",")[0].replace("-", "_");
                 currentLocale = lookup.getI18nResources().getAvailableLanguages().stream()
                         .filter(language -> language.startsWith(locale))
                         .findFirst()
                         .orElse(DEFAULT_LOCALE);
+            } else {
+                currentLocale = DEFAULT_LOCALE;
             }
-        } else {
-            currentLocale = DEFAULT_LOCALE;
+            // Add the locale to the helper options. This will be used when evaluating this helper again in the same
+            // request. This is done to increase the performance.
+            options.data(CURRENT_LOCALE, currentLocale);
         }
-
         Properties props = lookup.getI18nResources().getI18nResource(currentLocale);
         return props != null ? props.getProperty(key, key) : key;
     }

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/I18nHelper.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/I18nHelper.java
@@ -30,7 +30,6 @@ public class I18nHelper implements Helper<String> {
     public static final String HELPER_NAME = "i18n";
     private static final String DEFAULT_LOCALE = "en-us";
     private static final String LOCALE_HEADER = "Accept-Language";
-    private static final String LOCALE = "locale";
     private static final String DATA_KEY_CURRENT_LOCALE = "CURRENT_LOCALE";
 
     @Override
@@ -47,7 +46,7 @@ public class I18nHelper implements Helper<String> {
         // If not available, get the current locale.
         if (currentLocale == null) {
             Object localeHeaderValue;
-            Object localeParam = options.hash.get(LOCALE);
+            Object localeParam = options.hash.get("locale");
             if (localeParam != null) {
                 currentLocale = localeParam.toString();
             } else if ((localeHeaderValue = requestLookup.getRequest().getHeaders().get(LOCALE_HEADER)) != null) {

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/I18nHelper.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/I18nHelper.java
@@ -31,7 +31,7 @@ public class I18nHelper implements Helper<String> {
     private static final String DEFAULT_LOCALE = "en-us";
     private static final String LOCALE_HEADER = "Accept-Language";
     private static final String LOCALE = "locale";
-    private static final String CURRENT_LOCALE = "CURRENT_LOCALE";
+    private static final String DATA_KEY_CURRENT_LOCALE = "CURRENT_LOCALE";
 
     @Override
     public CharSequence apply(String key, Options options) throws IOException {
@@ -43,7 +43,7 @@ public class I18nHelper implements Helper<String> {
         Lookup lookup = options.data(HbsRenderable.DATA_KEY_LOOKUP);
 
         // Check whether the current locale is already available in the options.
-        String currentLocale = options.data(CURRENT_LOCALE);
+        String currentLocale = options.data(DATA_KEY_CURRENT_LOCALE);
         // If not available, get the current locale.
         if (currentLocale == null) {
             Object localeHeaderValue;
@@ -64,7 +64,7 @@ public class I18nHelper implements Helper<String> {
             }
             // Add the locale to the helper options. This will be used when evaluating this helper again in the same
             // request. This is done to increase the performance.
-            options.data(CURRENT_LOCALE, currentLocale);
+            options.data(DATA_KEY_CURRENT_LOCALE, currentLocale);
         }
         Properties props = lookup.getI18nResources().getI18nResource(currentLocale);
         return props != null ? props.getProperty(key, key) : key;

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/I18nHelper.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/I18nHelper.java
@@ -28,7 +28,7 @@ import java.util.Properties;
 public class I18nHelper implements Helper<String> {
 
     public static final String HELPER_NAME = "i18n";
-    private static final String DEFAULT_LOCALE = "en_US";
+    private static final String DEFAULT_LOCALE = "en-us";
     private static final String LOCALE_HEADER = "Accept-Language";
     private static final String LOCALE = "locale";
 

--- a/samples/apps/org.wso2.carbon.uuf.sample.pets-store.app/src/main/pages/index.hbs
+++ b/samples/apps/org.wso2.carbon.uuf.sample.pets-store.app/src/main/pages/index.hbs
@@ -4,19 +4,19 @@
 {{title "Home | " @config.appName}}
 {{#fillZone "content"}}
     <div class="page-header">
-        <h1>{{t "pets-store.welcome"}}</h1>
-        <p class="lead">{{t "pets-store.welcome.msg"}}</p>
+        <h1>{{i18n "pets-store.welcome"}}</h1>
+        <p class="lead">{{i18n "pets-store.welcome.msg"}}</p>
     </div>
     <div class="row">
         <div class="media tab-responsive">
             <div class="media-left col-xs-1 col-sm-1 col-md-2 col-lg-2 hidden-xs">
                 <ul class="list-group nav nav-pills nav-stacked" role="tablist">
                     <li class="list-group-item"><a href="{{@contextPath}}/pets"><i class="fw fw-tiles fw-2x"></i>
-                        {{t "pets-store.all"}}</a></li>
+                        {{i18n "pets-store.all"}}</a></li>
                     <li class="list-group-item"><a href="{{@contextPath}}/pets/new"><i class="fw fw-add fw-2x"></i>
-                        {{t "pets-store.add"}}</a></li>
+                        {{i18n "pets-store.add"}}</a></li>
                     <li class="list-group-item"><a href="{{@contextPath}}/pets/snowball"><i class="fw fw-star fw-2x">
-                    </i> {{t "pets-store.petOfTheMonth"}}</a></li>
+                    </i> {{i18n "pets-store.petOfTheMonth"}}</a></li>
                     <li class="list-group-item"><a href="{{@contextPath}}/pets/order"><i class="fw fw-store fw-2x">
                     </i> Order a new pet</a></li>
                     <li class="list-group-item"><a href="{{@contextPath}}/users"><i class="fw fw-user fw-2x">

--- a/samples/apps/org.wso2.carbon.uuf.sample.pets-store.app/src/main/pages/pets/index.hbs
+++ b/samples/apps/org.wso2.carbon.uuf.sample.pets-store.app/src/main/pages/pets/index.hbs
@@ -4,16 +4,16 @@
 {{title "Pets | " @config.appName}}
 {{#fillZone "content"}}
     <div class="page-header">
-        <h1>{{t "pets-store.list"}}</h1>
-        <p class="lead">{{t "pets-store.info"}}</p>
+        <h1>{{i18n "pets-store.list"}}</h1>
+        <p class="lead">{{i18n "pets-store.info"}}</p>
     </div>
     <table class="table table-responsive table-striped" id="members">
         <thead>
         <tr>
             <th>#</th>
-            <th>{{t "pets-store.add.pet.name"}}</th>
-            <th>{{t "pets-store.add.pet.category"}}</th>
-            <th>{{t "pets-store.add.pet.color"}}</th>
+            <th>{{i18n "pets-store.add.pet.name"}}</th>
+            <th>{{i18n "pets-store.add.pet.category"}}</th>
+            <th>{{i18n "pets-store.add.pet.color"}}</th>
         </tr>
         </thead>
         <tbody>

--- a/samples/apps/org.wso2.carbon.uuf.sample.pets-store.app/src/main/pages/pets/new.hbs
+++ b/samples/apps/org.wso2.carbon.uuf.sample.pets-store.app/src/main/pages/pets/new.hbs
@@ -5,12 +5,12 @@
 
 {{#fillZone "content"}}
     <div class="page-header">
-        <h1>{{t "pets-store.add.pet.details"}}</h1>
+        <h1>{{i18n "pets-store.add.pet.details"}}</h1>
     </div>
     {{#if petName}}
         <div class="alert alert-success" role="alert">
-            <i class="icon fw fw-success"></i><strong>{{t "pets-store.add.pet.success"}}</strong>
-            {{t "pets-store.add.pet.success.detail"}} {{petCategory}}, {{petName}}.
+            <i class="icon fw fw-success"></i><strong>{{i18n "pets-store.add.pet.success"}}</strong>
+            {{i18n "pets-store.add.pet.success.detail"}} {{petCategory}}, {{petName}}.
             <button type="button" class="close" aria-label="close" data-dismiss="alert">
                 <span aria-hidden="true">
                     <i class="fw fw-cancel"></i>
@@ -21,14 +21,14 @@
     <form class="form-horizontal" method="post">
         <div class="form-group">
             <div class="col-sm-12">
-                <label for="input-name" class="control-label">{{t "pets-store.add.pet.name"}} <span class="">*</span></label>
+                <label for="input-name" class="control-label">{{i18n "pets-store.add.pet.name"}} <span class="">*</span></label>
                 <input type="text" class="form-control" name="pet-name" placeholder="Type your pet's name here"
                        required>
             </div>
         </div>
         <div class="form-group">
             <div class="col-sm-12">
-                <label class="control-label">{{t "pets-store.add.pet.category"}}</label>
+                <label class="control-label">{{i18n "pets-store.add.pet.category"}}</label>
                 <select class="form-control" name="pet-category">
                     <option>puppy</option>
                     <option>kitten</option>
@@ -40,7 +40,7 @@
         </div>
         <div class="form-group">
             <div class="col-sm-12">
-                <label class="control-label">{{t "pets-store.add.pet.color"}}</label>
+                <label class="control-label">{{i18n "pets-store.add.pet.color"}}</label>
                 <select class="form-control">
                     <option>White</option>
                     <option>Black</option>
@@ -52,13 +52,13 @@
         </div>
         <div class="form-group">
             <div class="col-sm-12">
-                <label class="control-label">{{t "pets-store.add.pet.about"}}</label>
+                <label class="control-label">{{i18n "pets-store.add.pet.about"}}</label>
                 <textarea class="form-control" rows="3"></textarea>
             </div>
         </div>
         <div class="form-group">
             <div class="col-sm-12">
-                <button type="submit" class="btn btn-default btn-primary">{{t "pets-store.add.pet.submit"}}</button>
+                <button type="submit" class="btn btn-default btn-primary">{{i18n "pets-store.add.pet.submit"}}</button>
             </div>
         </div>
     </form>

--- a/samples/apps/org.wso2.carbon.uuf.sample.pets-store.app/src/main/pages/pets/{id}.hbs
+++ b/samples/apps/org.wso2.carbon.uuf.sample.pets-store.app/src/main/pages/pets/{id}.hbs
@@ -4,13 +4,13 @@
 {{#fillZone "content"}}
     {{css "css/pet-store.css"}}
     <div class="page-header">
-        <h1>{{t "pets-store.pet.info"}}</h1>
+        <h1>{{i18n "pets-store.pet.info"}}</h1>
     </div>
     <div class="col-md-8">
         {{fragment "thumbnail"}}
         <br />
         <div class="pet-info">
-            {{t "pets-store.pet.name"}} : {{@pathParams.id}}
+            {{i18n "pets-store.pet.name"}} : {{@pathParams.id}}
         </div>
     </div>
     <div class="col-md-4">


### PR DESCRIPTION
Fixes #154 

This PR will fix the issue of internationalization not working properly on some browsers. The locale to be used for each request is calculated when the helper is called for the first time and then it is stored in the i18n helper's **options** for the later use. This is done to improve performance.

Also this PR also renames the `{{t}}` helper to `{{i18n}}`.

