### PR TITLE
Fixing 'isInPage' and 'isInLayout' methods to return correct stack info

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/core/RequestLookup.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/core/RequestLookup.java
@@ -188,7 +188,7 @@ public class RequestLookup {
         }
 
         public boolean isInPage() {
-            return rendererStack.peekLast().equals(TYPE_PAGE);
+            return rendererStack.peekFirst().equals(TYPE_PAGE);
         }
 
         public boolean isInFragment() {
@@ -196,7 +196,7 @@ public class RequestLookup {
         }
 
         public boolean isInLayout() {
-            return rendererStack.peekLast().equals(TYPE_LAYOUT);
+            return rendererStack.contains(TYPE_LAYOUT);
         }
 
         void out(Page page) {


### PR DESCRIPTION
BUG INFO: **RenderingFlowTracker** is not correctly returning correct information for **isInPage** and **isInLayout** methods. Ex: If current fragment is loaded via a page, **isInPage** is returned as false.

RESOLVE #161