### PR TITLE
Fixing app deployment failing when 'i18n' helper is used in Fragments

### DIFF
--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/core/HbsRenderable.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/core/HbsRenderable.java
@@ -24,7 +24,7 @@ import org.wso2.carbon.uuf.core.API;
 import org.wso2.carbon.uuf.core.Lookup;
 import org.wso2.carbon.uuf.core.RequestLookup;
 import org.wso2.carbon.uuf.exception.UUFException;
-import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.registry.HbsHelperRegistry;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.registry.RuntimeHelperRegistry;
 import org.wso2.carbon.uuf.spi.Renderable;
 import org.wso2.carbon.uuf.spi.model.Model;
 
@@ -40,7 +40,7 @@ public abstract class HbsRenderable implements Renderable {
     public static final String DATA_KEY_API = HbsRenderable.class.getName() + "#api";
     public static final String DATA_KEY_CURRENT_WRITER = HbsRenderable.class.getName() + "#writer";
     public static final String DATA_KEY_RESOLVED_RESOURCES = HbsRenderable.class.getName() + "#resolved-resources";
-    private static final Handlebars HANDLEBARS = new Handlebars().with(new HbsHelperRegistry());
+    private static final Handlebars HANDLEBARS = new Handlebars().with(new RuntimeHelperRegistry());
 
     private final Template template;
     private final String absolutePath;

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/registry/InitHelperRegistry.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/registry/InitHelperRegistry.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.uuf.renderablecreator.hbs.helpers.registry;
+
+import com.github.jknack.handlebars.HelperRegistry;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.init.LayoutHelper;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.init.SecuredHelper;
+
+/**
+ * Handlebars helpers registry for pre-compilation stage.
+ * Secured, Layout, I18n and Missing helper is used in this registry.
+ *
+ * @Since 1.0.0
+ */
+public class InitHelperRegistry extends RuntimeHelperRegistry {
+
+    /**
+     * Registers necessary helpers for pre-compilation stage. We only register
+     * init (pre-compile time) helpers from helpers.init package.
+     *
+     * @param registry the Handlebars registry to be used for helper registration
+     */
+    protected void registerDefaultHelpers(final HelperRegistry registry) {
+        registry.registerHelper(SecuredHelper.HELPER_NAME, new SecuredHelper());
+        registry.registerHelper(LayoutHelper.HELPER_NAME, new LayoutHelper());
+        registry.registerHelperMissing((context, options) -> "");
+    }
+}

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/registry/RuntimeHelperRegistry.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/registry/RuntimeHelperRegistry.java
@@ -65,9 +65,9 @@ import java.util.Set;
  *
  * @since 1.0.0
  */
-public class HbsHelperRegistry implements HelperRegistry {
+public class RuntimeHelperRegistry implements HelperRegistry {
 
-    private final Logger logger = LoggerFactory.getLogger(HbsHelperRegistry.class);
+    private final Logger logger = LoggerFactory.getLogger(RuntimeHelperRegistry.class);
 
     /**
      * The helper registry.
@@ -82,7 +82,7 @@ public class HbsHelperRegistry implements HelperRegistry {
     /**
      * Default constructor that registers all the default hbs helpers and additionally registers UUF related helpers
      */
-    public HbsHelperRegistry() {
+    public RuntimeHelperRegistry() {
         registerDefaultHelpers(this);
     }
 

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/registry/RuntimeHelperRegistry.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/registry/RuntimeHelperRegistry.java
@@ -59,7 +59,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Default implementation of {@link HelperRegistry} used in UUF.
+ * Handlebars helpers registry for runtime.
  * Reusing the some code from {@link com.github.jknack.handlebars.helper.DefaultHelperRegistry} and additionally
  * including helpers written for UUF.
  *
@@ -197,9 +197,9 @@ public class RuntimeHelperRegistry implements HelperRegistry {
      * Register built-in and default helpers. We are not registering some of the unwanted helpers (partial, embedded,
      * i18n. etc) as they are replaced by the custom helpers written for UUF.
      *
-     * @param registry The handlebars instance.
+     * @param registry the Handlebars registry to be used for helper registration
      */
-    private void registerDefaultHelpers(final HelperRegistry registry) {
+    protected void registerDefaultHelpers(final HelperRegistry registry) {
         registry.registerHelper(WithHelper.NAME, WithHelper.INSTANCE);
         registry.registerHelper(IfHelper.NAME, IfHelper.INSTANCE);
         registry.registerHelper(UnlessHelper.NAME, UnlessHelper.INSTANCE);
@@ -225,8 +225,6 @@ public class RuntimeHelperRegistry implements HelperRegistry {
         registry.registerHelper(I18nHelper.HELPER_NAME, new I18nHelper());
         registry.registerHelper(TemplateHelper.HELPER_NAME, new TemplateHelper());
         registry.registerHelperMissing(new MissingHelper());
-        // decorator
-        registry.registerDecorator("inline", InlineDecorator.INSTANCE);
     }
 
     /**

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/internal/HbsPreprocessor.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/internal/HbsPreprocessor.java
@@ -22,6 +22,7 @@ import com.github.jknack.handlebars.io.TemplateSource;
 import org.wso2.carbon.uuf.exception.UUFException;
 import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.init.LayoutHelper;
 import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.init.SecuredHelper;
+import org.wso2.carbon.uuf.renderablecreator.hbs.helpers.registry.InitHelperRegistry;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -31,13 +32,7 @@ public class HbsPreprocessor {
 
     public static final String DATA_KEY_CURRENT_LAYOUT = HbsPreprocessor.class.getName() + "#layout";
     public static final String DATA_KEY_IS_SECURED = HbsPreprocessor.class.getName() + "#secured";
-    private static final Handlebars HANDLEBARS = new Handlebars();
-
-    static {
-        HANDLEBARS.registerHelper(LayoutHelper.HELPER_NAME, new LayoutHelper());
-        HANDLEBARS.registerHelper(SecuredHelper.HELPER_NAME, new SecuredHelper());
-        HANDLEBARS.registerHelperMissing((context, options) -> "");
-    }
+    private static final Handlebars HANDLEBARS = new Handlebars().with(new InitHelperRegistry());
 
     private final Optional<String> layout;
     private final boolean isSecured;


### PR DESCRIPTION
Fixes #167.

When i18n helper is used in fragments. It is not working. It throws error "java.util.MissingResourceException: Can't find bundle for base name messages, locale en_US".

This PR provides fix for above mentioned issue and rename the HbsHelperRegistry class into RuntimeHelperRegistry.