### PR TITLE
Improve fragment rendering logic to include JS and CSS resources

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/core/App.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/core/App.java
@@ -220,15 +220,13 @@ public class App {
         RequestLookup requestLookup = createRequestLookup(request, response);
         API api = new API(sessionRegistry, requestLookup);
 
-        JsonObject renderedFragment = new JsonObject();
-        renderedFragment.addProperty("html", fragment.render(model, lookup, requestLookup, api));
-        renderedFragment.addProperty(Placeholder.headJs.name(),
-                                     requestLookup.getPlaceholderContent(Placeholder.headJs).orElse(null));
-        renderedFragment.addProperty(Placeholder.js.name(),
-                                     requestLookup.getPlaceholderContent(Placeholder.js).orElse(null));
-        renderedFragment.addProperty(Placeholder.css.name(),
-                                     requestLookup.getPlaceholderContent(Placeholder.css).orElse(null));
-        return renderedFragment;
+        JsonObject output = new JsonObject();
+        output.addProperty("html", fragment.render(model, lookup, requestLookup, api));
+        output.addProperty(Placeholder.headJs.name(),
+                           requestLookup.getPlaceholderContent(Placeholder.headJs).orElse(null));
+        output.addProperty(Placeholder.js.name(), requestLookup.getPlaceholderContent(Placeholder.js).orElse(null));
+        output.addProperty(Placeholder.css.name(), requestLookup.getPlaceholderContent(Placeholder.css).orElse(null));
+        return output;
     }
 
     private boolean hasPage(String uriWithoutContextPath) {

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/RequestDispatcher.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/RequestDispatcher.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.uuf.internal;
 
+import com.google.gson.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.uuf.core.App;
@@ -29,6 +30,7 @@ import org.wso2.carbon.uuf.internal.io.StaticResolver;
 import org.wso2.carbon.uuf.spi.HttpRequest;
 import org.wso2.carbon.uuf.spi.HttpResponse;
 
+import static org.wso2.carbon.uuf.spi.HttpResponse.CONTENT_TYPE_APPLICATION_JSON;
 import static org.wso2.carbon.uuf.spi.HttpResponse.CONTENT_TYPE_TEXT_HTML;
 import static org.wso2.carbon.uuf.spi.HttpResponse.HEADER_CACHE_CONTROL;
 import static org.wso2.carbon.uuf.spi.HttpResponse.HEADER_EXPIRES;
@@ -84,16 +86,14 @@ public class RequestDispatcher {
 
     private void servePageOrFragment(App app, HttpRequest request, HttpResponse response) {
         try {
-            String html;
-            // set default and configured http response headers for security purpose
-            setResponseSecurityHeaders(app, response);
             if (request.isFragmentRequest()) {
-                html = app.renderFragment(request, response);
+                JsonObject renderedFragment = app.renderFragment(request, response);
+                response.setContent(STATUS_OK, renderedFragment.toString(), CONTENT_TYPE_APPLICATION_JSON);
             } else {
                 // Request for a page.
-                html = app.renderPage(request, response);
+                String html = app.renderPage(request, response);
+                response.setContent(STATUS_OK, html, CONTENT_TYPE_TEXT_HTML);
             }
-            response.setContent(STATUS_OK, html, CONTENT_TYPE_TEXT_HTML);
         } catch (UUFException e) {
             throw e;
         } catch (Exception e) {

--- a/components/uuf-core/src/test/java/org/wso2/carbon/uuf/core/AppTest.java
+++ b/components/uuf-core/src/test/java/org/wso2/carbon/uuf/core/AppTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.gson.JsonObject;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.wso2.carbon.uuf.api.Placeholder;
 import org.wso2.carbon.uuf.api.config.Configuration;
 import org.wso2.carbon.uuf.api.model.MapModel;
 import org.wso2.carbon.uuf.exception.PageRedirectException;
@@ -67,6 +68,20 @@ public class AppTest {
     private static Fragment createFragment(String name, String content) {
         Renderable renderable = (model, l, rl, a) -> content + (model.toMap().isEmpty() ? "" : model.toMap());
         return new Fragment(name, renderable, false);
+    }
+
+    private static Fragment createFragmentWithResources(String name, String content) {
+        Renderable renderable = (model, l, rl, a) -> content + (model.toMap().isEmpty() ? "" : model.toMap());
+        return new Fragment(name, renderable, false) {
+            @Override
+            public String render(Model model, Lookup lookup, RequestLookup requestLookup, API api) {
+                //requestLookup.addToPlaceholder("html", content);
+                requestLookup.addToPlaceholder(Placeholder.css, "CSS Content");
+                requestLookup.addToPlaceholder(Placeholder.js, "JS Content");
+                requestLookup.addToPlaceholder(Placeholder.headJs, "Head JS Content");
+                return content;
+            }
+        };
     }
 
     private static HttpRequest createRequest(String contextPath, String uriWithoutContextPath) {
@@ -145,6 +160,37 @@ public class AppTest {
         when(request.getFormParams()).thenReturn(emptyMap());
         renderedFragment = app.renderFragment(request, null);
         Assert.assertEquals(renderedFragment.get("html").getAsString(), fragment2Content);
+    }
+
+    @Test
+    public void testRenderFragmentWithResources() {
+        final String fragment1Content = "Fragment 1 with Resource content.";
+        Fragment f1 = createFragmentWithResources("cmp.f1", fragment1Content);
+        final String fragment2Content = "Fragment 2 with Resource content.";
+        Fragment f2 = createFragmentWithResources("cmp.f2", fragment2Content);
+        Component cmp = new Component("cmp", null, "/cmp", emptySortedSet(), ImmutableSet.of(f1, f2), emptySet(),
+                                      emptySet(), null);
+        Component rootComponent = new Component("root", null, Component.ROOT_COMPONENT_CONTEXT_PATH, emptySortedSet(),
+                                                emptySet(), emptySet(), singleton(cmp), null);
+        App app = new App(null, "/test", ImmutableSet.of(cmp, rootComponent), emptySet(), createConfiguration(), null,
+                          null);
+
+        HttpRequest request = createRequest(app.getContextPath(), "/fragments/cmp.f1");
+        when(request.getFormParams()).thenReturn(emptyMap());
+        JsonObject renderedFragment = app.renderFragment(request, null);
+        Assert.assertEquals(renderedFragment.get("html").getAsString(), fragment1Content);
+        Assert.assertEquals(renderedFragment.get("css").getAsString(), "CSS Content");
+        Assert.assertEquals(renderedFragment.get("js").getAsString(), "JS Content");
+        Assert.assertEquals(renderedFragment.get("headJs").getAsString(), "Head JS Content");
+
+        request = createRequest(app.getContextPath(), "/fragments/cmp.f2");
+        when(request.getFormParams()).thenReturn(emptyMap());
+        renderedFragment = app.renderFragment(request, null);
+        Assert.assertEquals(renderedFragment.get("html").getAsString(), fragment2Content);
+        Assert.assertEquals(renderedFragment.get("css").getAsString(), "CSS Content");
+        Assert.assertEquals(renderedFragment.get("js").getAsString(), "JS Content");
+        Assert.assertEquals(renderedFragment.get("headJs").getAsString(), "Head JS Content");
+
     }
 
     @Test

--- a/components/uuf-core/src/test/java/org/wso2/carbon/uuf/core/AppTest.java
+++ b/components/uuf-core/src/test/java/org/wso2/carbon/uuf/core/AppTest.java
@@ -71,11 +71,9 @@ public class AppTest {
     }
 
     private static Fragment createFragmentWithResources(String name, String content) {
-        Renderable renderable = (model, l, rl, a) -> content + (model.toMap().isEmpty() ? "" : model.toMap());
-        return new Fragment(name, renderable, false) {
+        return new Fragment(name, null, false) {
             @Override
             public String render(Model model, Lookup lookup, RequestLookup requestLookup, API api) {
-                //requestLookup.addToPlaceholder("html", content);
                 requestLookup.addToPlaceholder(Placeholder.css, "CSS Content");
                 requestLookup.addToPlaceholder(Placeholder.js, "JS Content");
                 requestLookup.addToPlaceholder(Placeholder.headJs, "Head JS Content");
@@ -153,13 +151,13 @@ public class AppTest {
 
         HttpRequest request = createRequest(app.getContextPath(), "/fragments/cmp.f1");
         when(request.getFormParams()).thenReturn(emptyMap());
-        JsonObject renderedFragment = app.renderFragment(request, null);
-        Assert.assertEquals(renderedFragment.get("html").getAsString(), fragment1Content);
+        JsonObject output = app.renderFragment(request, null);
+        Assert.assertEquals(output.get("html").getAsString(), fragment1Content);
 
         request = createRequest(app.getContextPath(), "/fragments/cmp.f2");
         when(request.getFormParams()).thenReturn(emptyMap());
-        renderedFragment = app.renderFragment(request, null);
-        Assert.assertEquals(renderedFragment.get("html").getAsString(), fragment2Content);
+        output = app.renderFragment(request, null);
+        Assert.assertEquals(output.get("html").getAsString(), fragment2Content);
     }
 
     @Test
@@ -175,11 +173,11 @@ public class AppTest {
 
         HttpRequest request = createRequest(app.getContextPath(), "/fragments/cmp.f1");
         when(request.getFormParams()).thenReturn(emptyMap());
-        JsonObject renderedFragment = app.renderFragment(request, null);
-        Assert.assertEquals(renderedFragment.get("html").getAsString(), fragment1Content);
-        Assert.assertEquals(renderedFragment.get("css").getAsString(), "CSS Content");
-        Assert.assertEquals(renderedFragment.get("js").getAsString(), "JS Content");
-        Assert.assertEquals(renderedFragment.get("headJs").getAsString(), "Head JS Content");
+        JsonObject output = app.renderFragment(request, null);
+        Assert.assertEquals(output.get("html").getAsString(), fragment1Content);
+        Assert.assertEquals(output.get("css").getAsString(), "CSS Content");
+        Assert.assertEquals(output.get("js").getAsString(), "JS Content");
+        Assert.assertEquals(output.get("headJs").getAsString(), "Head JS Content");
     }
 
     @Test
@@ -197,8 +195,8 @@ public class AppTest {
 
         HttpRequest request = createRequest(app.getContextPath(), "/fragments/cmp.f1");
         when(request.getFormParams()).thenReturn(formParams);
-        JsonObject renderedFragment = app.renderFragment(request, null);
-        Assert.assertEquals(renderedFragment.get("html").getAsString(), (fragment1Content + formParams.toString()));
+        JsonObject output = app.renderFragment(request, null);
+        Assert.assertEquals(output.get("html").getAsString(), (fragment1Content + formParams.toString()));
     }
 
     @Test

--- a/components/uuf-core/src/test/java/org/wso2/carbon/uuf/core/AppTest.java
+++ b/components/uuf-core/src/test/java/org/wso2/carbon/uuf/core/AppTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.gson.JsonObject;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.wso2.carbon.uuf.api.config.Configuration;
@@ -137,13 +138,13 @@ public class AppTest {
 
         HttpRequest request = createRequest(app.getContextPath(), "/fragments/cmp.f1");
         when(request.getFormParams()).thenReturn(emptyMap());
-        String html = app.renderFragment(request, null);
-        Assert.assertEquals(html, fragment1Content);
+        JsonObject renderedFragment = app.renderFragment(request, null);
+        Assert.assertEquals(renderedFragment.get("html").getAsString(), fragment1Content);
 
         request = createRequest(app.getContextPath(), "/fragments/cmp.f2");
         when(request.getFormParams()).thenReturn(emptyMap());
-        html = app.renderFragment(request, null);
-        Assert.assertEquals(html, fragment2Content);
+        renderedFragment = app.renderFragment(request, null);
+        Assert.assertEquals(renderedFragment.get("html").getAsString(), fragment2Content);
     }
 
     @Test
@@ -161,8 +162,8 @@ public class AppTest {
 
         HttpRequest request = createRequest(app.getContextPath(), "/fragments/cmp.f1");
         when(request.getFormParams()).thenReturn(formParams);
-        String html = app.renderFragment(request, null);
-        Assert.assertEquals(html, (fragment1Content + formParams.toString()));
+        JsonObject renderedFragment = app.renderFragment(request, null);
+        Assert.assertEquals(renderedFragment.get("html").getAsString(), (fragment1Content + formParams.toString()));
     }
 
     @Test

--- a/components/uuf-core/src/test/java/org/wso2/carbon/uuf/core/AppTest.java
+++ b/components/uuf-core/src/test/java/org/wso2/carbon/uuf/core/AppTest.java
@@ -166,9 +166,7 @@ public class AppTest {
     public void testRenderFragmentWithResources() {
         final String fragment1Content = "Fragment 1 with Resource content.";
         Fragment f1 = createFragmentWithResources("cmp.f1", fragment1Content);
-        final String fragment2Content = "Fragment 2 with Resource content.";
-        Fragment f2 = createFragmentWithResources("cmp.f2", fragment2Content);
-        Component cmp = new Component("cmp", null, "/cmp", emptySortedSet(), ImmutableSet.of(f1, f2), emptySet(),
+        Component cmp = new Component("cmp", null, "/cmp", emptySortedSet(), ImmutableSet.of(f1), emptySet(),
                                       emptySet(), null);
         Component rootComponent = new Component("root", null, Component.ROOT_COMPONENT_CONTEXT_PATH, emptySortedSet(),
                                                 emptySet(), emptySet(), singleton(cmp), null);
@@ -182,15 +180,6 @@ public class AppTest {
         Assert.assertEquals(renderedFragment.get("css").getAsString(), "CSS Content");
         Assert.assertEquals(renderedFragment.get("js").getAsString(), "JS Content");
         Assert.assertEquals(renderedFragment.get("headJs").getAsString(), "Head JS Content");
-
-        request = createRequest(app.getContextPath(), "/fragments/cmp.f2");
-        when(request.getFormParams()).thenReturn(emptyMap());
-        renderedFragment = app.renderFragment(request, null);
-        Assert.assertEquals(renderedFragment.get("html").getAsString(), fragment2Content);
-        Assert.assertEquals(renderedFragment.get("css").getAsString(), "CSS Content");
-        Assert.assertEquals(renderedFragment.get("js").getAsString(), "JS Content");
-        Assert.assertEquals(renderedFragment.get("headJs").getAsString(), "Head JS Content");
-
     }
 
     @Test


### PR DESCRIPTION
With this fix JS and CSS resources are included when a fragment is directly rendered

RESOLVE #129 