### PR TITLE
improve sendToClient to accept method & include encoding

### DIFF
--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/core/js/SendToClientFunction.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/core/js/SendToClientFunction.java
@@ -21,5 +21,5 @@ public interface SendToClientFunction {
 
     String NAME = "sendToClient";
 
-    void call(String name, Object value);
+    void call(String name, Object... value);
 }

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/JsFunctionsImpl.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/JsFunctionsImpl.java
@@ -165,8 +165,8 @@ public class JsFunctionsImpl {
                         "=" + GSON.toJson(values[0]) +
                         ";</script>";
                 api.getRequestLookup().addToPlaceholder(
-                        (values.length == 2 && "headJs".equalsIgnoreCase((String) values[1])) ? Placeholder.headJs :
-                                Placeholder.js, scriptTag);
+                        (values.length == 2 && Placeholder.headJs.name().equalsIgnoreCase((String) values[1])) ?
+                                Placeholder.headJs : Placeholder.js, scriptTag);
             };
         }
         return sendToClientFunction;

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/JsFunctionsImpl.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/JsFunctionsImpl.java
@@ -16,6 +16,7 @@
 
 package org.wso2.carbon.uuf.renderablecreator.hbs.impl.js;
 
+import com.github.jknack.handlebars.Handlebars;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -159,10 +160,13 @@ public class JsFunctionsImpl {
 
     public SendToClientFunction getSendToClientFunction() {
         if (sendToClientFunction == null) {
-            sendToClientFunction = (name, value) -> {
-                String scriptTag = "<script type=\"text/javascript\">var " + name + "=" + GSON.toJson(value) +
+            sendToClientFunction = (name, values) -> {
+                String scriptTag = "<script type=\"text/javascript\">var " + Handlebars.Utils.escapeExpression(name) +
+                        "=" + GSON.toJson(values[0]) +
                         ";</script>";
-                api.getRequestLookup().addToPlaceholder(Placeholder.js, scriptTag);
+                api.getRequestLookup().addToPlaceholder(
+                        (values.length == 2 && "headJs".equalsIgnoreCase((String) values[1])) ? Placeholder.headJs :
+                                Placeholder.js, scriptTag);
             };
         }
         return sendToClientFunction;

--- a/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/handlebars/JsFunctionsTest.java
+++ b/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/handlebars/JsFunctionsTest.java
@@ -67,6 +67,22 @@ public class JsFunctionsTest {
         Assert.assertEquals(api.getRequestLookup().getPlaceholderContent(Placeholder.js).get(), outputJS);
     }
 
+    @Test(dataProvider = "sendToClientJS")
+    public void testSendToClientWithJs(String varName, String inputJS, String outputJS) {
+        API api = createAPI();
+        JsFunctionsImpl jsFunctions = new JsFunctionsImpl(api, createLookup(), createRequestLookup());
+        jsFunctions.getSendToClientFunction().call(varName, inputJS, "js");
+        Assert.assertEquals(api.getRequestLookup().getPlaceholderContent(Placeholder.js).get(), outputJS);
+    }
+
+    @Test(dataProvider = "sendToClientJS")
+    public void testSendToClientWithHeadJs(String varName, String inputJS, String outputJS) {
+        API api = createAPI();
+        JsFunctionsImpl jsFunctions = new JsFunctionsImpl(api, createLookup(), createRequestLookup());
+        jsFunctions.getSendToClientFunction().call(varName, inputJS, "headJs");
+        Assert.assertEquals(api.getRequestLookup().getPlaceholderContent(Placeholder.headJs).get(), outputJS);
+    }
+
     private static API createAPI() {
         API api = mock(API.class);
         when(api.getRequestLookup()).thenReturn(new RequestLookup("/contextPath", mock(HttpRequest.class), null));


### PR DESCRIPTION
Before this improvement, "sendToClient" method is injecting the variables to the "js" placeholder in the layout. With this improvement variables can be injected to headJS as well

RESOLVE #194
RESOLVE #101 