### PR TITLE
Redirect post with correction

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/core/App.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/core/App.java
@@ -140,12 +140,20 @@ public class App {
                     uriWithoutContextPath.substring(0, uriWithoutContextPath.length() - 1) :
                     (uriWithoutContextPath + "/");
             if (hasPage(correctedUriWithoutContextPath)) {
-                // Redirecting to the correct page.
-                String correctedUri = request.getContextPath() + correctedUriWithoutContextPath;
-                if (request.getQueryString() != null) {
-                    correctedUri = correctedUri + '?' + request.getQueryString();
+                if (request.isGetRequest()) {
+                    // Redirecting to the correct page.
+                    String correctedUri = request.getContextPath() + correctedUriWithoutContextPath;
+                    if (request.getQueryString() != null) {
+                        correctedUri = correctedUri + '?' + request.getQueryString();
+                    }
+                    throw new PageRedirectException(correctedUri, e);
+                } else {
+                    // If GET, we correct, since this can be an end-user error. But if POST it's the responsibility of
+                    // the dev to use correct URL. Because HTTP POST redirect is not well supported.
+                    // See : https://softwareengineering.stackexchange.com/q/99894
+                    String message = e.getMessage() + " Retry with correct URI ending " + correctedUriWithoutContextPath;
+                    return renderErrorPage(new PageNotFoundException(message, e), requestLookup, api, theme);
                 }
-                throw new PageRedirectException(correctedUri, e);
             } else {
                 return renderErrorPage(e, requestLookup, api, theme);
             }

--- a/components/uuf-core/src/test/java/org/wso2/carbon/uuf/core/AppTest.java
+++ b/components/uuf-core/src/test/java/org/wso2/carbon/uuf/core/AppTest.java
@@ -87,6 +87,7 @@ public class AppTest {
         when(request.getContextPath()).thenReturn(contextPath);
         when(request.getUri()).thenReturn(contextPath + uriWithoutContextPath);
         when(request.getUriWithoutContextPath()).thenReturn(uriWithoutContextPath);
+        when(request.isGetRequest()).thenReturn(true);
         return request;
     }
 


### PR DESCRIPTION
In the current implementation, URL correction is done for both GET and POST requests.

With this PR, now we show an error message (in a 404 error page) saying that to retry with correct URI ending (if correct URI if found) for POST requests.