### PR TITLE
Fixing Java Docs

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/api/Server.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/api/Server.java
@@ -21,7 +21,18 @@ package org.wso2.carbon.uuf.api;
 import org.wso2.carbon.uuf.spi.HttpRequest;
 import org.wso2.carbon.uuf.spi.HttpResponse;
 
+/**
+ * A server that serves for HTTP requests.
+ *
+ * @since 1.0.0
+ */
 public interface Server {
 
+    /**
+     * Serves for the specified HTTP request and writes the output to the given HTTP response.
+     *
+     * @param request  HTTP request to be served
+     * @param response HTTP response which will carry the result of this serve
+     */
     void serve(HttpRequest request, HttpResponse response);
 }

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/api/auth/Session.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/api/auth/Session.java
@@ -34,6 +34,8 @@ import java.util.concurrent.ThreadLocalRandom;
  * The {@link org.wso2.carbon.uuf.internal.auth.SessionRegistry SessionRegistry} uses this class to create a session
  * between an HTTP client and an HTTP server. The session persists for a specified time period, across more than one
  * connection or page request from the user.
+ *
+ * @since 1.0.0
  */
 public class Session implements Serializable {
 
@@ -48,24 +50,49 @@ public class Session implements Serializable {
     private final String csrfToken;
     private String themeName;
 
+    /**
+     * Creates a new session instance with the specified user.
+     *
+     * @param user user of the session.
+     */
     public Session(User user) {
         this.sessionId = sessionIdGenerator.generateId();
         this.user = user;
         this.csrfToken = sessionIdGenerator.generateId();
     }
 
+    /**
+     * Returns the ID of this session.
+     *
+     * @return ID of this session
+     */
     public String getSessionId() {
         return sessionId;
     }
 
+    /**
+     * Returns the user of this session.
+     *
+     * @return user of this session
+     */
     public User getUser() {
         return user;
     }
 
+    /**
+     * Returns the name of the theme of this session.
+     *
+     * @return theme name of this session
+     */
     public String getThemeName() {
         return themeName;
     }
 
+    /**
+     * Returns the CSRF token of this session.
+     *
+     * @return CSRF token of this session
+     */
     public String getCsrfToken() {
         return csrfToken;
     }
@@ -77,21 +104,36 @@ public class Session implements Serializable {
         this.themeName = themeName;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int hashCode() {
         return Objects.hash(sessionId);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean equals(Object obj) {
         return (obj != null) && (obj instanceof Session) && (sessionId.equals(((Session) obj).sessionId));
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String toString() {
         return "{\"sessionId\": \"" + sessionId + "\", \"user\": \"" + user + "\", \"theme\": \"" + themeName + "\"}";
     }
 
+    /**
+     * Validates the given session ID.
+     *
+     * @param sessionId session ID to validate
+     * @return {@code true} if session ID is valid, {@code false} if not
+     */
     public static boolean isValidSessionId(String sessionId) {
         return (sessionId != null) && !sessionId.isEmpty() && (sessionId.length() == Session.SESSION_ID_LENGTH * 2);
     }
@@ -128,6 +170,11 @@ public class Session implements Serializable {
             this.sessionIdLength = sessionIdLength;
         }
 
+        /**
+         * Generates and returns a new session ID.
+         *
+         * @return session ID
+         */
         public synchronized String generateId() {
             byte randomBytes[] = new byte[16];
             // Render the result as a String of hexadecimal digits

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/api/model/MapModel.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/api/model/MapModel.java
@@ -23,21 +23,34 @@ import org.wso2.carbon.uuf.spi.model.Model;
 import java.util.Map;
 
 /**
- * Implements the {@link Model} interface to provide a Map based model.
+ * Implements the {@link Model} interface to provide a {@link java.util.Map map} based model.
+ *
+ * @since 1.0.0
  */
 public class MapModel implements Model {
 
     private Map<String, Object> map;
 
+    /**
+     * Creates a new model with the specified map.
+     *
+     * @param map data of the model
+     */
     public MapModel(Map<String, Object> map) {
         this.map = map;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void combine(Map<String, Object> other) {
         map.putAll(other);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Map<String, Object> toMap() {
         return map;

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/api/reference/AppReference.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/api/reference/AppReference.java
@@ -20,23 +20,76 @@ package org.wso2.carbon.uuf.api.reference;
 
 import java.util.stream.Stream;
 
+/**
+ * A reference to an UUF app artifact.
+ *
+ * @since 1.0.0
+ */
 public interface AppReference {
 
+    /**
+     * Name of the directory that contains UUF components.
+     */
     String DIR_NAME_COMPONENTS = "components";
+    /**
+     * Name of the directory that contains customized UUF components.
+     */
     String DIR_NAME_CUSTOMIZATIONS = "customizations";
+    /**
+     * Name of the directory that contains UUF themes.
+     */
     String DIR_NAME_THEMES = "themes";
+    /**
+     * Name of the file that has the dependency tree of the UUF components.
+     */
     String FILE_NAME_DEPENDENCY_TREE = "dependency-tree.yaml";
+    /**
+     * Name of the file that has the app configurations.
+     */
     String FILE_NAME_CONFIGURATION = "configuration.yaml";
 
+    /**
+     * Returns the name of the UUF app represented by this reference.
+     *
+     * @return name of the UUF app
+     */
     String getName();
 
+    /**
+     * Returns a reference to the UUF component that belongs to the UUF app represented by this reference.
+     *
+     * @param componentContext context of the UUF component
+     * @return reference to the UUF component
+     */
     ComponentReference getComponentReference(String componentContext);
 
+    /**
+     * Returns UUF theme reference of the UUF app represented by this reference.
+     *
+     * @return references for UUF themes of this UUF app
+     */
     Stream<ThemeReference> getThemeReferences();
 
+    /**
+     * Returns a reference to the dependency tree file of the UUF app represented by this reference.
+     *
+     * @return reference to the dependency tree file
+     * @see #FILE_NAME_DEPENDENCY_TREE
+     */
     FileReference getDependencyTree();
 
+    /**
+     * Returns a reference to the configuration file of the UUF app represented by this reference.
+     *
+     * @return reference to the configuration file of this UUF app
+     * @see #FILE_NAME_CONFIGURATION
+     */
     FileReference getConfiguration();
 
+    /**
+     * Returns the absolute path to the UUF app represented by this reference.
+     *
+     * @return absolute path to the UUF app
+     */
     String getPath();
 }

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/spi/HttpRequest.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/spi/HttpRequest.java
@@ -24,12 +24,24 @@ import java.util.Map;
 
 /**
  * Represent a HTTP request.
+ *
+ * @since 1.0.0
  */
 public interface HttpRequest {
 
+    /**
+     * HTTP header <a href="https://tools.ietf.org/html/rfc2616#section-14.17">content type</a>.
+     */
     String HEADER_CONTENT_TYPE = "Content-Type";
+    /**
+     * HTTP header <a href="https://tools.ietf.org/html/rfc2616#section-14.13">content length</a>.
+     */
     String HEADER_CONTENT_LENGTH = "Content-Length";
+    /**
+     * HTTP header <a href="https://tools.ietf.org/html/rfc2616#section-14.4">accept language</a>.
+     */
     String HEADER_ACCEPT_LANGUAGE = "Accept-Language";
+
     String COOKIE_UUFSESSIONID = "UUFSESSIONID";
     String COOKIE_CSRFTOKEN = "CSRFTOKEN";
 
@@ -42,7 +54,8 @@ public interface HttpRequest {
 
     /**
      * Return whether this request is a GET request or not.
-     * @return {@code true} if this is a GET request and {@code false} if this is a POST request
+     *
+     * @return {@code true} if this is a GET request, {@code false} if this is not a GET request (POST)
      */
     boolean isGetRequest();
 
@@ -200,8 +213,18 @@ public interface HttpRequest {
      */
     int getRemotePort();
 
+    /**
+     * Returns a string representation of this request.
+     *
+     * @return a string representation of this request
+     */
     String toString();
 
+    /**
+     * Returns whether this is a valid request or not.
+     *
+     * @return {@code true} if this is a valid request, {@code false} if not
+     */
     default boolean isValid() {
         String uri = getUri();
 
@@ -227,30 +250,67 @@ public interface HttpRequest {
         return true;
     }
 
+    /**
+     * Returns whether this request is for a static resource.
+     *
+     * @return {@code true} if this is a request to a static resource, {@code false} if not
+     */
     default boolean isStaticResourceRequest() {
         return getUriWithoutContextPath().startsWith("/public/");
     }
 
+    /**
+     * Returns whether this request is for a static resource in a component.
+     *
+     * @return {@code true} if this is a request to a static resource in a component, {@code false} if not
+     */
     default boolean isComponentStaticResourceRequest() {
         return getUriWithoutContextPath().startsWith(UriUtils.COMPONENT_STATIC_RESOURCES_URI_PREFIX);
     }
 
+    /**
+     * Returns whether this request is for a static resource in a theme.
+     *
+     * @return {@code true} if this is a request to a static resource in a theme, {@code false} if not
+     */
     default boolean isThemeStaticResourceRequest() {
         return getUriWithoutContextPath().startsWith(UriUtils.THEMES_STATIC_RESOURCES_URI_PREFIX);
     }
 
+    /**
+     * Returns whether this request is for the debugger.
+     *
+     * @return {@code true} if this is a request to the debugger, {@code false} if not
+     */
     default boolean isDebugRequest() {
         return getUriWithoutContextPath().startsWith("/debug/");
     }
 
+    /**
+     * Returns whether this request is for a fragment
+     *
+     * @return {@code true} if this is a request to a fragment, {@code false} if not
+     */
     default boolean isFragmentRequest() {
         return getUriWithoutContextPath().startsWith(UriUtils.FRAGMENTS_URI_PREFIX);
     }
 
+    /**
+     * Returns whether this request is for the default favicon.
+     *
+     * @return {@code true} if this is a request to the default favicon, {@code false} if not
+     */
     default boolean isDefaultFaviconRequest() {
         return getUri().equals("/favicon.ico");
     }
 
+    /**
+     * Returns the context path of the specified URI.
+     *
+     * @param uri URI
+     * @return context path of the specified URI
+     * @see #getContextPath()
+     */
     static String getContextPath(String uri) {
         int secondSlash = uri.indexOf('/', 1); // An URI must start with a slash.
         if (secondSlash == -1) {
@@ -261,6 +321,13 @@ public interface HttpRequest {
         }
     }
 
+    /**
+     * Returns the part of the specified URI from the end of the context path to the end of the URI.
+     *
+     * @param uri URI
+     * @return part of the URI without the context path
+     * @see #getUriWithoutContextPath()
+     */
     static String getUriWithoutContextPath(String uri) {
         int secondSlash = uri.indexOf('/', 1); // An URI must start with a slash.
         if (secondSlash == -1) {

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/spi/HttpResponse.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/spi/HttpResponse.java
@@ -18,12 +18,16 @@
 
 package org.wso2.carbon.uuf.spi;
 
-import javax.ws.rs.core.MultivaluedMap;
 import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Path;
-import java.util.Map;
+import javax.ws.rs.core.MultivaluedMap;
 
+/**
+ * Represents a HTTP response.
+ *
+ * @since 1.0.0
+ */
 public interface HttpResponse {
 
     int STATUS_OK = 200;
@@ -50,54 +54,164 @@ public interface HttpResponse {
     String HEADER_EXPIRES = "Expires";
     String HEADER_PRAGMA = "Pragma";
 
+    /**
+     * Sets the <a href="https://tools.ietf.org/html/rfc2616#section-10">HTTP status code</a> of this response to the
+     * specified integer.
+     *
+     * @param statusCode HTTP status code to be set
+     */
     void setStatus(int statusCode);
 
+    /**
+     * Returns the <a href="https://tools.ietf.org/html/rfc2616#section-10">HTTP status code</a> of this response.
+     *
+     * @return HTTP status code of this response
+     */
     int getStatus();
 
+    /**
+     * Sets the specified textual content to this response. This is equivalent to
+     * {@code setContent(content, }{@link #CONTENT_TYPE_TEXT_PLAIN}{@code )}
+     *
+     * @param content textual content to be set
+     * @see #setContent(String, String)
+     */
     default void setContent(String content) {
         setContent(content, CONTENT_TYPE_TEXT_PLAIN);
     }
 
+    /**
+     * Sets the specified textual content and the content type to this response.
+     *
+     * @param content     textual content to be set
+     * @param contentType MIME type of the content
+     */
     void setContent(String content, String contentType);
 
+    /**
+     * Sets the specified file content to this response.
+     *
+     * @param content file content to be set
+     */
     void setContent(File content);
 
+    /**
+     * Sets the specified file content and the content type to this response.
+     *
+     * @param content     file content to be set
+     * @param contentType MIME type of the content
+     */
     void setContent(File content, String contentType);
 
+    /**
+     * Sets the specified content and the content type to this response.
+     *
+     * @param content     content to be set
+     * @param contentType MIME type of the content
+     */
     void setContent(Object content, String contentType);
 
+    /**
+     * Sets the file content located by the specified path to this response.
+     *
+     * @param content path of the file content to be set
+     */
     default void setContent(Path content) {
         setContent(content.toFile());
     }
 
+    /**
+     * Sets the file content located by the specified path and the content type to this response.
+     *
+     * @param content     path of the file content to be set
+     * @param contentType MIME type of the content
+     */
     default void setContent(Path content, String contentType) {
         setContent(content.toFile(), contentType);
     }
 
+    /**
+     * Sets the content read through the specified input stream and the content type to this response.
+     *
+     * @param content     input stream to the content to be set
+     * @param contentType MIME type of the content
+     */
     void setContent(InputStream content, String contentType);
 
+    /**
+     * Sets the specified the HTTP status code and the textual content to this response.
+     *
+     * @param statusCode HTTP status code to be set
+     * @param content    textual content to be set
+     */
     default void setContent(int statusCode, String content) {
         setStatus(statusCode);
         setContent(content);
     }
 
+    /**
+     * Sets the specified the HTTP status code and the textual content to this response.
+     *
+     * @param statusCode  HTTP status code to be set
+     * @param content     textual content to be set
+     * @param contentType MIME type of the content
+     */
     default void setContent(int statusCode, String content, String contentType) {
         setStatus(statusCode);
         setContent(content);
         setContentType(contentType);
     }
 
+    /**
+     * Returns the content of this response.
+     *
+     * @return the content of this response
+     */
     Object getContent();
 
-    void setContentType(String type);
+    /**
+     * Sets the <a href="https://www.iana.org/assignments/media-types/media-types.xhtml">MIME type</a> of this response.
+     *
+     * @param contentType MIME type to be set
+     */
+    void setContentType(String contentType);
 
+    /**
+     * Returns the <a href="https://www.iana.org/assignments/media-types/media-types.xhtml">MIME type</a> of this
+     * response.
+     *
+     * @return MIME type of this response
+     */
     String getContentType();
 
+    /**
+     * Adds a new value to the specified HTTP header of this response.
+     *
+     * @param name  name of the HTTP header
+     * @param value value to be added; if {@code null} existing value(s) will be removed
+     */
     void setHeader(String name, String value);
 
+    /**
+     * Returns the HTTP headers of this response.
+     *
+     * @return HTTP headers of this response.
+     */
     MultivaluedMap<String, String> getHeaders();
 
+    /**
+     * Adds a cookie to this response.
+     *
+     * @param name  name of the cookie
+     * @param value value of the cookie
+     */
     void addCookie(String name, String value);
 
+    /**
+     * Returns the value of the specified cookie of this response.
+     *
+     * @param name name of the cookie
+     * @return value of the specified cookie of this response
+     */
     String getCookie(String name);
 }

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/spi/auth/User.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/spi/auth/User.java
@@ -21,15 +21,40 @@ package org.wso2.carbon.uuf.spi.auth;
 
 import java.io.Serializable;
 
+/**
+ * Represents an user.
+ *
+ * @since 1.0.0
+ */
 public interface User extends Serializable {
 
+    /**
+     * Returns the username of this user.
+     *
+     * @return username of this user
+     */
     String getUsername();
 
+    /**
+     * Checks whether this user has the specified permission.
+     * @param resourceUri resource of the permission to be checked
+     * @param action action of the permission to be checked
+     * @return {@code true} if this user has the permission, {@code false} if not
+     */
     boolean hasPermission(String resourceUri, String action);
 
+    /**
+     * {@inheritDoc}
+     */
     int hashCode();
 
+    /**
+     * {@inheritDoc}
+     */
     boolean equals(Object obj);
 
+    /**
+     * {@inheritDoc}
+     */
     String toString();
 }

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/spi/model/Model.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/spi/model/Model.java
@@ -20,9 +20,23 @@ package org.wso2.carbon.uuf.spi.model;
 
 import java.util.Map;
 
+/**
+ * Represents the data model passed to a {@link org.wso2.carbon.uuf.spi.Renderable} when rendering.
+ *
+ * @since 1.0.0
+ */
 public interface Model {
 
+    /**
+     * Combines the specified map with the this data model.
+     *
+     * @param other map of data to be combined
+     */
     void combine(Map<String, Object> other);
 
+    /**
+     * Converts and returns this data model as a map.
+     * @return map representation of this data model
+     */
     Map<String, Object> toMap();
 }

--- a/components/uuf-httpconnector-msf4j/src/main/java/org/wso2/carbon/uuf/httpconnector/msf4j/MicroserviceHttpResponse.java
+++ b/components/uuf-httpconnector-msf4j/src/main/java/org/wso2/carbon/uuf/httpconnector/msf4j/MicroserviceHttpResponse.java
@@ -19,14 +19,14 @@ package org.wso2.carbon.uuf.httpconnector.msf4j;
 import org.apache.commons.io.FilenameUtils;
 import org.wso2.carbon.uuf.spi.HttpResponse;
 
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.NewCookie;
-import javax.ws.rs.core.Response;
 import java.io.File;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Response;
 
 /**
  * UUF HttpResponse implementation based on JAX-RS Response.
@@ -91,8 +91,8 @@ public class MicroserviceHttpResponse implements HttpResponse {
     }
 
     @Override
-    public void setContentType(String type) {
-        this.contentType = type;
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
     }
 
     @Override


### PR DESCRIPTION
Java Docs in following classes/interfaces are added/fixed in this PR.
- org.wso2.carbon.uuf.spi.auth.User
- org.wso2.carbon.uuf.api.auth.Session
- org.wso2.carbon.uuf.spi.model.Model
- org.wso2.carbon.uuf.api.model.MapModel
- org.wso2.carbon.uuf.api.Server
- org.wso2.carbon.uuf.api.reference.AppReference
- org.wso2.carbon.uuf.spi.HttpRequest
- org.wso2.carbon.uuf.spi.HttpResponse