### PR TITLE
Replace "final static" with "static final"

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/debug/Debugger.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/debug/Debugger.java
@@ -55,7 +55,7 @@ public class Debugger {
     private static final UriPatten URI_PATTEN_PAGE_INDEX = new UriPatten("/debug/");
     private static final UriPatten URI_PATTEN_RESOURCES = new UriPatten("/debug/{+resource}");
 
-    private final static JsonParser JSON_PARSER = new JsonParser();
+    private static final JsonParser JSON_PARSER = new JsonParser();
     private static final Logger LOGGER = LoggerFactory.getLogger(Debugger.class);
     private static final boolean IS_DEBUGGING_ENABLED = UUFServer.isDevModeEnabled();
 


### PR DESCRIPTION
Keywords `final static` is replaced with `static final` due to the convention. The changed files are as follows:

- `Debugger.java`