### PR TITLE
Change `carbon.sh` permission to 0755

### DIFF
--- a/product/src/assembly/bin.xml
+++ b/product/src/assembly/bin.xml
@@ -49,7 +49,7 @@
         <fileSet>
             <directory>carbon-home/bin</directory>
             <outputDirectory>bin</outputDirectory>
-            <fileMode>644</fileMode>
+            <fileMode>755</fileMode>
         </fileSet>
 
         <fileSet>


### PR DESCRIPTION
Fix `carbon.sh` not being able to be executed right away after
extracting
Resolves #218