### PR TITLE
Add plugin provider

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/exception/PluginLoadingException.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/exception/PluginLoadingException.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uuf.exception;
+
+/**
+ * Indicates an error occurred during loading and instantiation of a plugin.
+ *
+ * @since 1.0.0
+ */
+public class PluginLoadingException extends UUFException {
+
+    /**
+     * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause(Throwable)}.
+     */
+    public PluginLoadingException() {
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause}.
+     *
+     * @param message the detail message of the exception
+     */
+    public PluginLoadingException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null :
+     * cause.toString())} which typically contains the class and detail message of the {@code cause}.
+     *
+     * @param cause the cause of the exception
+     */
+    public PluginLoadingException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message the detail message of the exception
+     * @param cause   the cause of the exception
+     */
+    public PluginLoadingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/exception/UUFException.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/exception/UUFException.java
@@ -18,19 +18,46 @@
 
 package org.wso2.carbon.uuf.exception;
 
+/**
+ * Indicates a generic exception occurred in UUF.
+ *
+ * @since 1.0.0
+ */
 public class UUFException extends RuntimeException {
 
+    /**
+     * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause(Throwable)}.
+     */
     public UUFException() {
     }
 
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause}.
+     *
+     * @param message the detail message of the exception
+     */
     public UUFException(String message) {
         super(message);
     }
 
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null :
+     * cause.toString())} which typically contains the class and detail message of the {@code cause}.
+     *
+     * @param cause the cause of the exception
+     */
     public UUFException(Throwable cause) {
         super(cause);
     }
 
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message the detail message of the exception
+     * @param cause   the cause of the exception
+     */
     public UUFException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
@@ -79,7 +79,8 @@ public class AppCreator {
     private final ClassLoaderProvider classLoaderProvider;
     private final PluginProvider pluginProvider;
 
-    public AppCreator(Set<RenderableCreator> renderableCreators, ClassLoaderProvider classLoaderProvider, PluginProvider pluginProvider) {
+    public AppCreator(Set<RenderableCreator> renderableCreators, ClassLoaderProvider classLoaderProvider,
+                      PluginProvider pluginProvider) {
         this.renderableCreators = new HashMap<>();
         this.supportedExtensions = new HashSet<>();
         for (RenderableCreator renderableCreator : renderableCreators) {

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
@@ -73,11 +73,13 @@ import static org.wso2.carbon.uuf.internal.util.NameUtils.getFullyQualifiedName;
 public class AppCreator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AppCreator.class);
+
     private final Map<String, RenderableCreator> renderableCreators;
     private final Set<String> supportedExtensions;
     private final ClassLoaderProvider classLoaderProvider;
+    private final PluginProvider pluginProvider;
 
-    public AppCreator(Set<RenderableCreator> renderableCreators, ClassLoaderProvider classLoaderProvider) {
+    public AppCreator(Set<RenderableCreator> renderableCreators, ClassLoaderProvider classLoaderProvider, PluginProvider pluginProvider) {
         this.renderableCreators = new HashMap<>();
         this.supportedExtensions = new HashSet<>();
         for (RenderableCreator renderableCreator : renderableCreators) {
@@ -87,6 +89,7 @@ public class AppCreator {
             supportedExtensions.addAll(renderableCreator.getSupportedFileExtensions());
         }
         this.classLoaderProvider = classLoaderProvider;
+        this.pluginProvider = pluginProvider;
     }
 
     public App createApp(AppReference appReference, String contextPath) {

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/ClassLoaderProvider.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/ClassLoaderProvider.java
@@ -23,19 +23,19 @@ import org.wso2.carbon.uuf.api.reference.ComponentReference;
 import java.util.Dictionary;
 
 /**
- * A provider that gives the class loader for a given component.
+ * A provider that gives class loaders for UUF components.
  *
  * @since 1.0.0
  */
 public interface ClassLoaderProvider {
 
     /**
-     * Returns class loader of the given component.
+     * Returns a class loader of the specified UUF component.
      *
-     * @param componentName      full component name
-     * @param componentVersion   component version
-     * @param componentReference component reference
-     * @return class loader for specified component
+     * @param componentName      fully qualified name of the component
+     * @param componentVersion   version of the component
+     * @param componentReference reference to the component
+     * @return class loader for the specified component
      */
     ClassLoader getClassLoader(String componentName, String componentVersion, ComponentReference componentReference);
 

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/OsgiPluginProvider.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/OsgiPluginProvider.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uuf.internal.deployment;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.util.tracker.ServiceTracker;
+import org.wso2.carbon.uuf.exception.PluginLoadingException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Plugins provider for plugins that are OSGi services.
+ *
+ * @since 1.0.0
+ */
+@Component(name = "org.wso2.carbon.uuf.internal.deployment.OsgiPluginProvider",
+           service = PluginProvider.class,
+           immediate = true,
+           property = {
+                   "componentName=wso2-uuf-server"
+           }
+)
+public class OsgiPluginProvider implements PluginProvider {
+
+    private final Map<Class, ServiceTracker> serviceTrackers = new HashMap<>();
+    private BundleContext bundleContext = null;
+
+    @Activate
+    protected void activate(BundleContext bundleContext) {
+        this.bundleContext = bundleContext;
+    }
+
+    @Deactivate
+    protected void deactivate(BundleContext bundleContext) {
+        serviceTrackers.values().forEach(ServiceTracker::close);
+        serviceTrackers.clear();
+        this.bundleContext = null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T getPluginInstance(Class<T> type, String className, ClassLoader classLoader)
+            throws PluginLoadingException {
+        T plugin = loadOsgiPlugin(type, className);
+        return (plugin != null) ? plugin : loadNonOsgiPlugin(type, className, classLoader);
+    }
+
+    private <T> T loadOsgiPlugin(Class<T> type, String className) {
+        if (bundleContext == null) {
+            return null;
+        }
+
+        ServiceTracker<T, T> serviceTracker = getServiceTracker(type);
+        @SuppressWarnings("unchecked")
+        T[] services = serviceTracker.getServices((T[]) new Object[serviceTracker.size()]);
+        for (T service : services) {
+            if ((service != null) && (service.getClass().getName().equals(className))) {
+                return service;
+            }
+        }
+
+        return null;
+    }
+
+    private <T> T loadNonOsgiPlugin(Class<T> type, String className, ClassLoader classLoader) {
+        Object pluginInstance;
+        try {
+            pluginInstance = classLoader.loadClass(className).newInstance();
+        } catch (ClassNotFoundException e) {
+            throw new PluginLoadingException(
+                    "Cannot load plugin '" + className + "' via the class loader '" + classLoader + "'.", e);
+
+        } catch (IllegalAccessException | InstantiationException | SecurityException e) {
+            throw new PluginLoadingException(
+                    "Cannot instantiation plugin '" + className + "' via the class loader '" + classLoader + "'.", e);
+        }
+
+        try {
+            return type.cast(pluginInstance);
+        } catch (ClassCastException e) {
+            throw new PluginLoadingException(
+                    "Plugin '" + className + "' is not a sub class of the plugin type '" + type.getName() + "'.", e);
+        }
+    }
+
+    private <T> ServiceTracker<T, T> getServiceTracker(Class<T> serviceClass) {
+        @SuppressWarnings("unchecked")
+        ServiceTracker<T, T> serviceTracker = serviceTrackers.get(serviceClass);
+        if (serviceTracker == null) {
+            serviceTracker = new ServiceTracker<>(bundleContext, serviceClass, null);
+            serviceTracker.open();
+            serviceTrackers.put(serviceClass, serviceTracker);
+        }
+        return serviceTracker;
+    }
+}

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/PluginProvider.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/PluginProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uuf.internal.deployment;
+
+
+import org.wso2.carbon.uuf.exception.PluginLoadingException;
+
+/**
+ * A provider that gives instances of plugins for an uuf app.
+ *
+ * @since 1.0.0
+ */
+public interface PluginProvider {
+
+    /**
+     * Returns an instance of the specified plugin by loading the plugin class through the specified class loader.
+     *
+     * @param type        plugin type class
+     * @param className   plugin class name
+     * @param classLoader class loader to be used to load the plugin class
+     * @param <T>         plugin type
+     * @return instance of the plugin
+     * @throws PluginLoadingException if en error occurred when loading or instantiation of the plugin
+     */
+    <T> T getPluginInstance(Class<T> type, String className, ClassLoader classLoader) throws PluginLoadingException;
+}

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/io/deployment/ArtifactAppDeployer.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/io/deployment/ArtifactAppDeployer.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.uuf.internal.UUFServer;
 import org.wso2.carbon.uuf.internal.deployment.AppCreator;
 import org.wso2.carbon.uuf.internal.deployment.AppDeployer;
 import org.wso2.carbon.uuf.internal.deployment.ClassLoaderProvider;
+import org.wso2.carbon.uuf.internal.deployment.PluginProvider;
 import org.wso2.carbon.uuf.internal.io.reference.ArtifactAppReference;
 import org.wso2.carbon.uuf.internal.io.util.ZipArtifactHandler;
 import org.wso2.carbon.uuf.internal.util.NameUtils;
@@ -57,17 +58,17 @@ public class ArtifactAppDeployer implements AppDeployer {
     private final ConcurrentMap<String, AppArtifact> pendingToDeployArtifacts;
     private final Object lock;
 
-    public ArtifactAppDeployer(Set<RenderableCreator> renderableCreators) {
-        this(Paths.get(System.getProperty("carbon.home", "."), "deployment", "uufapps").toString(), renderableCreators);
+    public ArtifactAppDeployer(Set<RenderableCreator> renderableCreators, PluginProvider pluginProvider) {
+        this(Paths.get(System.getProperty("carbon.home", "."), "deployment", "uufapps").toString(), renderableCreators, pluginProvider);
     }
 
-    public ArtifactAppDeployer(String appsRepositoryPath, Set<RenderableCreator> renderableCreators) {
-        this(appsRepositoryPath, renderableCreators, new BundleClassLoaderProvider());
+    public ArtifactAppDeployer(String appsRepositoryPath, Set<RenderableCreator> renderableCreators, PluginProvider pluginProvider) {
+        this(appsRepositoryPath, renderableCreators, new BundleClassLoaderProvider(), pluginProvider);
     }
 
     public ArtifactAppDeployer(String appsRepositoryPath, Set<RenderableCreator> renderableCreators,
-                               ClassLoaderProvider classLoaderProvider) {
-        this(Paths.get(appsRepositoryPath), new AppCreator(renderableCreators, classLoaderProvider));
+                               ClassLoaderProvider classLoaderProvider, PluginProvider pluginProvider) {
+        this(Paths.get(appsRepositoryPath), new AppCreator(renderableCreators, classLoaderProvider, pluginProvider));
     }
 
     public ArtifactAppDeployer(Path appsRepository, AppCreator appCreator) {

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/io/deployment/ArtifactAppDeployer.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/io/deployment/ArtifactAppDeployer.java
@@ -59,10 +59,12 @@ public class ArtifactAppDeployer implements AppDeployer {
     private final Object lock;
 
     public ArtifactAppDeployer(Set<RenderableCreator> renderableCreators, PluginProvider pluginProvider) {
-        this(Paths.get(System.getProperty("carbon.home", "."), "deployment", "uufapps").toString(), renderableCreators, pluginProvider);
+        this(Paths.get(System.getProperty("carbon.home", "."), "deployment", "uufapps").toString(), renderableCreators,
+             pluginProvider);
     }
 
-    public ArtifactAppDeployer(String appsRepositoryPath, Set<RenderableCreator> renderableCreators, PluginProvider pluginProvider) {
+    public ArtifactAppDeployer(String appsRepositoryPath, Set<RenderableCreator> renderableCreators,
+                               PluginProvider pluginProvider) {
         this(appsRepositoryPath, renderableCreators, new BundleClassLoaderProvider(), pluginProvider);
     }
 

--- a/components/uuf-core/src/test/java/org/wso2/carbon/uuf/internal/deployment/RestApiDeploymentTest.java
+++ b/components/uuf-core/src/test/java/org/wso2/carbon/uuf/internal/deployment/RestApiDeploymentTest.java
@@ -95,7 +95,7 @@ public class RestApiDeploymentTest {
         }).when(classLoaderProvider).deployAPI(any(), any());
 
         // Create app creator.
-        AppCreator appCreator = new AppCreator(Collections.emptySet(), classLoaderProvider);
+        AppCreator appCreator = new AppCreator(Collections.emptySet(), classLoaderProvider, null);
         appCreator.createApp(appReference, appContextPath);
 
         String expectedApiContextPath = appContextPath + "/root/apis" + apiUri;


### PR DESCRIPTION
`PluginProvider` gives the capability to load UUF plugins (i.e. Authenticator, Session Manager, Microservice etc.) without tightly coupling to plugin instantiation. 

`OsgiPluginProvider` class assists to load plugins that can be OSGi services.

Note: `PluginProvider` is **only** used for UUF internal housekeeping, and it is not a public API.