### PR TITLE
Move PluginLoadingException to internal exception package

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/OsgiPluginProvider.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/OsgiPluginProvider.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.carbon.uuf.exception.PluginLoadingException;
+import org.wso2.carbon.uuf.internal.exception.PluginLoadingException;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/PluginProvider.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/PluginProvider.java
@@ -19,7 +19,7 @@
 package org.wso2.carbon.uuf.internal.deployment;
 
 
-import org.wso2.carbon.uuf.exception.PluginLoadingException;
+import org.wso2.carbon.uuf.internal.exception.PluginLoadingException;
 
 /**
  * A provider that gives instances of plugins for an uuf app.

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/exception/PluginLoadingException.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/exception/PluginLoadingException.java
@@ -16,7 +16,9 @@
  * under the License.
  */
 
-package org.wso2.carbon.uuf.exception;
+package org.wso2.carbon.uuf.internal.exception;
+
+import org.wso2.carbon.uuf.exception.UUFException;
 
 /**
  * Indicates an error occurred during loading and instantiation of a plugin.


### PR DESCRIPTION
This PR moves `PluginLoadingException` class from `org.wso2.carbon.uuf.exception` package to `org.wso2.carbon.uuf.internal.exception` package.

`PluginLoadingException` is thrown in `PluginProvider` which is an internal class. Hence `PluginLoadingException` should be in the internal exception package.