### PR TITLE
Move ConfigurationException class to 'internal.exception' package

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
@@ -40,7 +40,6 @@ import org.wso2.carbon.uuf.core.Layout;
 import org.wso2.carbon.uuf.core.Page;
 import org.wso2.carbon.uuf.core.Theme;
 import org.wso2.carbon.uuf.core.UriPatten;
-import org.wso2.carbon.uuf.exception.ConfigurationException;
 import org.wso2.carbon.uuf.exception.UUFException;
 import org.wso2.carbon.uuf.internal.deployment.parser.AppConfig;
 import org.wso2.carbon.uuf.internal.deployment.parser.ComponentConfig;
@@ -48,6 +47,7 @@ import org.wso2.carbon.uuf.internal.deployment.parser.DependencyNode;
 import org.wso2.carbon.uuf.internal.deployment.parser.PropertyFileParser;
 import org.wso2.carbon.uuf.internal.deployment.parser.ThemeConfig;
 import org.wso2.carbon.uuf.internal.deployment.parser.YamlFileParser;
+import org.wso2.carbon.uuf.internal.exception.ConfigurationException;
 import org.wso2.carbon.uuf.internal.util.NameUtils;
 import org.wso2.carbon.uuf.spi.RenderableCreator;
 

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/parser/PropertyFileParser.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/parser/PropertyFileParser.java
@@ -19,8 +19,8 @@
 package org.wso2.carbon.uuf.internal.deployment.parser;
 
 import org.wso2.carbon.uuf.api.reference.FileReference;
-import org.wso2.carbon.uuf.exception.ConfigurationException;
 import org.wso2.carbon.uuf.exception.FileOperationException;
+import org.wso2.carbon.uuf.internal.exception.ConfigurationException;
 
 import java.io.IOException;
 import java.io.StringReader;

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/parser/YamlFileParser.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/parser/YamlFileParser.java
@@ -19,8 +19,8 @@
 package org.wso2.carbon.uuf.internal.deployment.parser;
 
 import org.wso2.carbon.uuf.api.reference.FileReference;
-import org.wso2.carbon.uuf.exception.ConfigurationException;
 import org.wso2.carbon.uuf.exception.FileOperationException;
+import org.wso2.carbon.uuf.internal.exception.ConfigurationException;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/exception/ConfigurationException.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/exception/ConfigurationException.java
@@ -16,7 +16,9 @@
  * under the License.
  */
 
-package org.wso2.carbon.uuf.exception;
+package org.wso2.carbon.uuf.internal.exception;
+
+import org.wso2.carbon.uuf.exception.UUFException;
 
 /**
  * Indicates an error happens when reading or parsing or loading or processing configuration.

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/io/util/MimeMapper.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/io/util/MimeMapper.java
@@ -18,8 +18,8 @@
 
 package org.wso2.carbon.uuf.internal.io.util;
 
-import org.wso2.carbon.uuf.exception.ConfigurationException;
 import org.wso2.carbon.uuf.exception.FileOperationException;
+import org.wso2.carbon.uuf.internal.exception.ConfigurationException;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/components/uuf-core/src/test/java/org/wso2/carbon/uuf/internal/deployment/parser/PropertyFileParserTest.java
+++ b/components/uuf-core/src/test/java/org/wso2/carbon/uuf/internal/deployment/parser/PropertyFileParserTest.java
@@ -21,8 +21,8 @@ package org.wso2.carbon.uuf.internal.deployment.parser;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.wso2.carbon.uuf.api.reference.FileReference;
-import org.wso2.carbon.uuf.exception.ConfigurationException;
 import org.wso2.carbon.uuf.exception.FileOperationException;
+import org.wso2.carbon.uuf.internal.exception.ConfigurationException;
 
 import java.util.Properties;
 

--- a/components/uuf-core/src/test/java/org/wso2/carbon/uuf/internal/deployment/parser/YamlFileParserTest.java
+++ b/components/uuf-core/src/test/java/org/wso2/carbon/uuf/internal/deployment/parser/YamlFileParserTest.java
@@ -21,8 +21,8 @@ package org.wso2.carbon.uuf.internal.deployment.parser;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.wso2.carbon.uuf.api.reference.FileReference;
-import org.wso2.carbon.uuf.exception.ConfigurationException;
 import org.wso2.carbon.uuf.exception.FileOperationException;
+import org.wso2.carbon.uuf.internal.exception.ConfigurationException;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
This PR moves the `ConfigurationException` class from `org.wso2.carbon.uuf.exception` package to `org.wso2.carbon.uuf.internal.exception` package.

All usages of the `ConfigurationException` class are in the `org.wso2.carbon.uuf.internal` package. Also `ConfigurationException` class is not used in outside of the `uuf-core` module. Hence, `ConfigurationException` class should be an internal class of the `uuf-core` module.