### PR TITLE
Remove usage of UUFException and IllegalArgumentException in AppCreator class

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
@@ -40,7 +40,6 @@ import org.wso2.carbon.uuf.core.Layout;
 import org.wso2.carbon.uuf.core.Page;
 import org.wso2.carbon.uuf.core.Theme;
 import org.wso2.carbon.uuf.core.UriPatten;
-import org.wso2.carbon.uuf.exception.UUFException;
 import org.wso2.carbon.uuf.internal.deployment.parser.AppConfig;
 import org.wso2.carbon.uuf.internal.deployment.parser.ComponentConfig;
 import org.wso2.carbon.uuf.internal.deployment.parser.DependencyNode;
@@ -48,6 +47,7 @@ import org.wso2.carbon.uuf.internal.deployment.parser.PropertyFileParser;
 import org.wso2.carbon.uuf.internal.deployment.parser.ThemeConfig;
 import org.wso2.carbon.uuf.internal.deployment.parser.YamlFileParser;
 import org.wso2.carbon.uuf.internal.exception.ConfigurationException;
+import org.wso2.carbon.uuf.internal.exception.DeploymentException;
 import org.wso2.carbon.uuf.internal.util.NameUtils;
 import org.wso2.carbon.uuf.spi.RenderableCreator;
 
@@ -294,7 +294,7 @@ public class AppCreator {
     private RenderableCreator getRenderableCreator(FileReference fileReference) {
         RenderableCreator renderableCreator = renderableCreators.get(fileReference.getExtension());
         if (renderableCreator == null) {
-            throw new UUFException(
+            throw new DeploymentException(
                     "Cannot find a RenderableCreator for file type '" + fileReference.getExtension() + "'.");
         }
         return renderableCreator;

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
@@ -244,7 +244,7 @@ public class AppCreator {
                 Fragment fragment = availableFragments.get(NameUtils.getFullyQualifiedName(componentName,
                                                                                            fragmentName));
                 if (fragment == null) {
-                    throw new IllegalArgumentException(
+                    throw new ConfigurationException(
                             "Fragment '" + fragmentName + "' given in the binding entry '" + entry +
                                     "' does not exists in component '" + componentName + "' or its dependencies " +
                                     componentDependencies.stream().map(Component::getName).collect(joining(",")) + ".");
@@ -281,7 +281,7 @@ public class AppCreator {
             if (layout != null) {
                 return new Page(uriPatten, prd.getRenderable(), prd.isSecured(), layout);
             } else {
-                throw new IllegalArgumentException(
+                throw new DeploymentException(
                         "Layout '" + layoutName + "' used in page '" + pageRenderingFile.getRelativePath() +
                                 "' does not exists in component '" + componentName + "' or its dependencies.");
             }

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/AppCreator.java
@@ -46,8 +46,8 @@ import org.wso2.carbon.uuf.internal.deployment.parser.DependencyNode;
 import org.wso2.carbon.uuf.internal.deployment.parser.PropertyFileParser;
 import org.wso2.carbon.uuf.internal.deployment.parser.ThemeConfig;
 import org.wso2.carbon.uuf.internal.deployment.parser.YamlFileParser;
+import org.wso2.carbon.uuf.internal.exception.AppCreationException;
 import org.wso2.carbon.uuf.internal.exception.ConfigurationException;
-import org.wso2.carbon.uuf.internal.exception.DeploymentException;
 import org.wso2.carbon.uuf.internal.util.NameUtils;
 import org.wso2.carbon.uuf.spi.RenderableCreator;
 
@@ -281,7 +281,7 @@ public class AppCreator {
             if (layout != null) {
                 return new Page(uriPatten, prd.getRenderable(), prd.isSecured(), layout);
             } else {
-                throw new DeploymentException(
+                throw new AppCreationException(
                         "Layout '" + layoutName + "' used in page '" + pageRenderingFile.getRelativePath() +
                                 "' does not exists in component '" + componentName + "' or its dependencies.");
             }
@@ -294,7 +294,7 @@ public class AppCreator {
     private RenderableCreator getRenderableCreator(FileReference fileReference) {
         RenderableCreator renderableCreator = renderableCreators.get(fileReference.getExtension());
         if (renderableCreator == null) {
-            throw new DeploymentException(
+            throw new AppCreationException(
                     "Cannot find a RenderableCreator for file type '" + fileReference.getExtension() + "'.");
         }
         return renderableCreator;

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/exception/AppCreationException.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/exception/AppCreationException.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uuf.internal.exception;
+
+/**
+ * Indicates an error occurred when creating an app.
+ *
+ * @since 1.0.0
+ */
+public class AppCreationException extends DeploymentException {
+
+    /**
+     * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause(Throwable)}.
+     */
+    public AppCreationException() {
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause}.
+     *
+     * @param message the detail message of the exception
+     */
+    public AppCreationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null :
+     * cause.toString())} which typically contains the class and detail message of the {@code cause}.
+     *
+     * @param cause the cause of the exception
+     */
+    public AppCreationException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message the detail message of the exception
+     * @param cause   the cause of the exception
+     */
+    public AppCreationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/exception/ConfigurationException.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/exception/ConfigurationException.java
@@ -18,14 +18,12 @@
 
 package org.wso2.carbon.uuf.internal.exception;
 
-import org.wso2.carbon.uuf.exception.UUFException;
-
 /**
  * Indicates an error happens when reading or parsing or loading or processing configuration.
  *
  * @since 1.0.0
  */
-public class ConfigurationException extends UUFException {
+public class ConfigurationException extends DeploymentException {
 
     /**
      * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may


### PR DESCRIPTION
This PR removes usage of generic `org.wso2.carbon.uuf.exception.UUFException` and `java.lang.IllegalArgumentException` exceptions from `org.wso2.carbon.uuf.internal.deployment.AppCreator` class. Instead more specific `org.wso2.carbon.uuf.internal.exception.ConfigurationException` and `org.wso2.carbon.uuf.internal.exception.AppCreationException` exceptions are used.