### PR TITLE
Remove in-bundle, internal OSGi service components from UUF core

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/UUFServer.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/UUFServer.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.uuf.core.App;
 import org.wso2.carbon.uuf.exception.UUFException;
 import org.wso2.carbon.uuf.internal.deployment.AppDeployer;
 import org.wso2.carbon.uuf.internal.deployment.DeploymentNotifier;
+import org.wso2.carbon.uuf.internal.deployment.OsgiPluginProvider;
 import org.wso2.carbon.uuf.internal.deployment.PluginProvider;
 import org.wso2.carbon.uuf.internal.deployment.RestApiDeployer;
 import org.wso2.carbon.uuf.internal.io.deployment.ArtifactAppDeployer;
@@ -119,19 +120,6 @@ public class UUFServer implements Server, RequiredCapabilityListener {
         }
     }
 
-    @Reference(name = "pluginProvider",
-               service = PluginProvider.class,
-               cardinality = ReferenceCardinality.MANDATORY,
-               policy = ReferencePolicy.DYNAMIC,
-               unbind = "unsetPluginProvider")
-    protected void setPluginProvider(PluginProvider pluginProvider) {
-        this.pluginProvider = pluginProvider;
-    }
-
-    protected void unsetPluginProvider(PluginProvider pluginProvider) {
-        this.pluginProvider = null;
-    }
-
     @Reference(name = "restApiDeployer",
                service = RestApiDeployer.class,
                cardinality = ReferenceCardinality.MANDATORY,
@@ -156,6 +144,7 @@ public class UUFServer implements Server, RequiredCapabilityListener {
         stop();
         this.bundleContext = null;
         deploymentNotifier = null;
+        pluginProvider = null;
         serverServiceRegistration.unregister();
         LOGGER.debug("UUF Server deactivated.");
     }
@@ -163,6 +152,7 @@ public class UUFServer implements Server, RequiredCapabilityListener {
     @Override
     public void onAllRequiredCapabilitiesAvailable() {
         deploymentNotifier = new WhiteboardDeploymentNotifier(bundleContext);
+        pluginProvider = new OsgiPluginProvider(bundleContext);
         appDeployer = createAppDeployer();
         LOGGER.debug("ArtifactAppDeployer is ready.");
 

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/UUFServer.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/UUFServer.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.uuf.exception.UUFException;
 import org.wso2.carbon.uuf.internal.deployment.AppDeployer;
 import org.wso2.carbon.uuf.internal.deployment.DeploymentNotifier;
 import org.wso2.carbon.uuf.internal.deployment.OsgiPluginProvider;
+import org.wso2.carbon.uuf.internal.deployment.OsgiRestApiDeployer;
 import org.wso2.carbon.uuf.internal.deployment.PluginProvider;
 import org.wso2.carbon.uuf.internal.deployment.RestApiDeployer;
 import org.wso2.carbon.uuf.internal.io.deployment.ArtifactAppDeployer;
@@ -120,19 +121,6 @@ public class UUFServer implements Server, RequiredCapabilityListener {
         }
     }
 
-    @Reference(name = "restApiDeployer",
-               service = RestApiDeployer.class,
-               cardinality = ReferenceCardinality.MANDATORY,
-               policy = ReferencePolicy.DYNAMIC,
-               unbind = "unsetRestApiDeployer")
-    protected void setRestApiDeployer(RestApiDeployer restApiDeployer) {
-        this.restApiDeployer = restApiDeployer;
-    }
-
-    protected void unsetRestApiDeployer(RestApiDeployer restApiDeployer) {
-        this.restApiDeployer = null;
-    }
-
     @Activate
     protected void activate(BundleContext bundleContext) {
         this.bundleContext = bundleContext;
@@ -143,8 +131,9 @@ public class UUFServer implements Server, RequiredCapabilityListener {
     protected void deactivate(BundleContext bundleContext) {
         stop();
         this.bundleContext = null;
-        deploymentNotifier = null;
         pluginProvider = null;
+        restApiDeployer = null;
+        deploymentNotifier = null;
         serverServiceRegistration.unregister();
         LOGGER.debug("UUF Server deactivated.");
     }
@@ -153,6 +142,7 @@ public class UUFServer implements Server, RequiredCapabilityListener {
     public void onAllRequiredCapabilitiesAvailable() {
         deploymentNotifier = new WhiteboardDeploymentNotifier(bundleContext);
         pluginProvider = new OsgiPluginProvider(bundleContext);
+        restApiDeployer = new OsgiRestApiDeployer(bundleContext);
         appDeployer = createAppDeployer();
         LOGGER.debug("ArtifactAppDeployer is ready.");
 

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/OsgiPluginProvider.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/OsgiPluginProvider.java
@@ -19,12 +19,7 @@
 package org.wso2.carbon.uuf.internal.deployment;
 
 import org.osgi.framework.BundleContext;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.util.tracker.ServiceTracker;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.wso2.carbon.uuf.internal.exception.PluginLoadingException;
 
 import java.util.HashMap;
@@ -35,31 +30,14 @@ import java.util.Map;
  *
  * @since 1.0.0
  */
-@Component(name = "org.wso2.carbon.uuf.internal.deployment.OsgiPluginProvider",
-           service = PluginProvider.class,
-           immediate = true,
-           property = {
-                   "componentName=wso2-uuf-OSGi-plugin-provider"
-           }
-)
 public class OsgiPluginProvider implements PluginProvider {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(OsgiPluginProvider.class);
-    private final Map<Class, ServiceTracker> serviceTrackers = new HashMap<>();
-    private BundleContext bundleContext = null;
+    private final BundleContext bundleContext;
+    private final Map<Class, ServiceTracker> serviceTrackers;
 
-    @Activate
-    protected void activate(BundleContext bundleContext) {
+    public OsgiPluginProvider(BundleContext bundleContext) {
         this.bundleContext = bundleContext;
-        LOGGER.debug("OsgiPluginProvider activated.");
-    }
-
-    @Deactivate
-    protected void deactivate(BundleContext bundleContext) {
-        serviceTrackers.values().forEach(ServiceTracker::close);
-        serviceTrackers.clear();
-        this.bundleContext = null;
-        LOGGER.debug("OsgiPluginProvider deactivated.");
+        this.serviceTrackers = new HashMap<>();
     }
 
     /**

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/OsgiRestApiDeployer.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/deployment/OsgiRestApiDeployer.java
@@ -19,9 +19,6 @@
 package org.wso2.carbon.uuf.internal.deployment;
 
 import org.osgi.framework.BundleContext;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.uuf.api.RestApi;
@@ -37,28 +34,14 @@ import java.util.Hashtable;
  *
  * @since 1.0.0
  */
-@Component(name = "org.wso2.carbon.uuf.internal.deployment.OsgiRestApiDeployer",
-           service = RestApiDeployer.class,
-           immediate = true,
-           property = {
-                   "componentName=wso2-uuf-OSGi-REST-API-deployer"
-           }
-)
 public class OsgiRestApiDeployer implements RestApiDeployer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OsgiRestApiDeployer.class);
-    private BundleContext bundleContext;
 
-    @Activate
-    protected void activate(BundleContext bundleContext) {
+    private final BundleContext bundleContext;
+
+    public OsgiRestApiDeployer(BundleContext bundleContext) {
         this.bundleContext = bundleContext;
-        LOGGER.debug("OsgiRestApiDeployer activated.");
-    }
-
-    @Deactivate
-    protected void deactivate(BundleContext bundleContext) {
-        this.bundleContext = null;
-        LOGGER.debug("OsgiRestApiDeployer deactivated.");
     }
 
     /**


### PR DESCRIPTION
This PR changes following OSGi service components which are internal and only used inside the UUF core bundle to normal classes.
- `org.wso2.carbon.uuf.internal.deployment.OsgiRestApiDeployer`
- `org.wso2.carbon.uuf.internal.deployment.OsgiPluginProvider`

Instead of making them to be OSGi service components, now they are instantiated in `UUFServer` OSGi component by passing the `bundleContext`.