### PR TITLE
Move HTTP request dispatching logic in UUFServer.serve() to RequestDispatcher.serve()

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/UUFServer.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/UUFServer.java
@@ -90,7 +90,7 @@ public class UUFServer implements Server, RequiredCapabilityListener {
                     "A RenderableCreator for '" + renderableCreator.getSupportedFileExtensions() +
                             "' extensions is already registered");
         }
-        LOGGER.info("RenderableCreator '{}' registered for {} extensions.",
+        LOGGER.debug("RenderableCreator '{}' registered for {} extensions.",
                     renderableCreator.getClass().getName(), renderableCreator.getSupportedFileExtensions());
     }
 
@@ -101,7 +101,7 @@ public class UUFServer implements Server, RequiredCapabilityListener {
      */
     protected void unsetRenderableCreator(RenderableCreator renderableCreator) {
         renderableCreators.remove(renderableCreator);
-        LOGGER.info("RenderableCreator '{}' unregistered for {} extensions.",
+        LOGGER.debug("RenderableCreator '{}' unregistered for {} extensions.",
                     renderableCreator.getClass().getName(), renderableCreator.getSupportedFileExtensions());
         if (appRegistry != null) {
             // Remove apps that might have used the removed renderable creator to create.
@@ -131,7 +131,7 @@ public class UUFServer implements Server, RequiredCapabilityListener {
     @Override
     public void onAllRequiredCapabilitiesAvailable() {
         serverServiceRegistration = bundleContext.registerService(Server.class, this, null);
-        LOGGER.info("'{}' registered as a Server.", getClass().getName());
+        LOGGER.debug("'{}' registered as a Server.", getClass().getName());
 
         pluginProvider = new OsgiPluginProvider(bundleContext);
         restApiDeployer = new OsgiRestApiDeployer(bundleContext);

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/UUFServer.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/UUFServer.java
@@ -31,8 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.kernel.startupresolver.RequiredCapabilityListener;
 import org.wso2.carbon.uuf.api.Server;
-import org.wso2.carbon.uuf.core.App;
-import org.wso2.carbon.uuf.exception.UUFException;
 import org.wso2.carbon.uuf.internal.deployment.AppCreator;
 import org.wso2.carbon.uuf.internal.deployment.AppFinder;
 import org.wso2.carbon.uuf.internal.deployment.AppRegistry;
@@ -52,10 +50,6 @@ import org.wso2.carbon.uuf.spi.RenderableCreator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import static org.wso2.carbon.uuf.spi.HttpResponse.STATUS_BAD_REQUEST;
-import static org.wso2.carbon.uuf.spi.HttpResponse.STATUS_INTERNAL_SERVER_ERROR;
-import static org.wso2.carbon.uuf.spi.HttpResponse.STATUS_NOT_FOUND;
 
 @Component(name = "org.wso2.carbon.uuf.internal.UUFServer",
            service = RequiredCapabilityListener.class,
@@ -156,37 +150,7 @@ public class UUFServer implements Server, RequiredCapabilityListener {
      */
     @Override
     public void serve(HttpRequest request, HttpResponse response) {
-        if (!request.isValid()) {
-            requestDispatcher.serveDefaultErrorPage(STATUS_BAD_REQUEST, "Invalid URI '" + request.getUri() + "'.",
-                                                    response);
-            return;
-        }
-        if (request.isDefaultFaviconRequest()) {
-            requestDispatcher.serveDefaultFavicon(request, response);
-            return;
-        }
-
-        App app;
-        try {
-            app = appRegistry.getApp(request.getContextPath());
-        } catch (UUFException e) {
-            String msg = "A server error occurred while serving for request '" + request + "'.";
-            LOGGER.error(msg, e);
-            requestDispatcher.serveDefaultErrorPage(STATUS_INTERNAL_SERVER_ERROR, msg, response);
-            return;
-        } catch (Exception e) {
-            String msg = "An unexpected error occurred while serving for request '" + request + "'.";
-            LOGGER.error(msg, e);
-            requestDispatcher.serveDefaultErrorPage(STATUS_INTERNAL_SERVER_ERROR, msg, response);
-            return;
-        }
-
-        if (app != null) {
-            requestDispatcher.serve(app, request, response);
-        } else {
-            requestDispatcher.serveDefaultErrorPage(STATUS_NOT_FOUND, "Cannot find an app for context path '" +
-                    request.getContextPath() + "'.", response);
-        }
+        requestDispatcher.serve(request, response, appRegistry);
     }
 
     public void start() {


### PR DESCRIPTION
This PR moves the HTTP request dispatching logic in the `serve(HttpRequest request, HttpResponse response)` method of the `org.wso2.carbon.uuf.internal.UUFServer` class to `serve(HttpRequest request, HttpResponse response, AppRegistry appRegistry)` method of the `org.wso2.carbon.uuf.internal.RequestDispatcher` class.