### PR TITLE
Correct UUF samples to include autocomplete=off for password fields

### DIFF
--- a/samples/components/org.wso2.carbon.uuf.sample.simple-auth.ui/src/main/pages/login.hbs
+++ b/samples/components/org.wso2.carbon.uuf.sample.simple-auth.ui/src/main/pages/login.hbs
@@ -46,7 +46,8 @@
                                     <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5">
                                         <div class="input-group input-wrap">
                                             <input type="password" class="form-control" name="password"
-                                                   placeholder="{{i18n "simple-auth.page.login.form.password.placeholder"}}" />
+                                                   placeholder="{{i18n "simple-auth.page.login.form.password.placeholder"}}"
+                                                   autocomplete="off" />
                                         </div>
                                     </div>
                                 </div>

--- a/samples/components/org.wso2.carbon.uuf.sample.simple-auth.ui/src/main/pages/register.hbs
+++ b/samples/components/org.wso2.carbon.uuf.sample.simple-auth.ui/src/main/pages/register.hbs
@@ -47,14 +47,15 @@
                                         <label for="password" class="control-label">
                                             {{i18n "simple-auth.page.register.form.password"}}
                                         </label>
-                                        <input type="password" name="password" id="password" class="form-control" />
+                                        <input type="password" name="password" id="password" class="form-control"
+                                               autocomplete="off"/>
                                     </div>
                                     <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5">
                                         <label for="confirm-password" class="control-label">
                                             {{i18n "simple-auth.page.register.form.password-confirm"}}
                                         </label>
                                         <input type="password" name="confirm-password" id="confirm-password"
-                                               class="form-control" />
+                                               class="form-control" autocomplete="off"/>
                                     </div>
                                 </div>
                                 <div class="form-group">


### PR DESCRIPTION
Correcting UUF sample component "simple-auth.ui" to send autocomplete="off" attribute in HTML password input fields. 

Resolves #262