### PR TITLE
Set X-Frame-Options:DENY by default

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/RequestDispatcher.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/internal/RequestDispatcher.java
@@ -48,6 +48,7 @@ import static org.wso2.carbon.uuf.spi.HttpResponse.HEADER_LOCATION;
 import static org.wso2.carbon.uuf.spi.HttpResponse.HEADER_PRAGMA;
 import static org.wso2.carbon.uuf.spi.HttpResponse.HEADER_X_CONTENT_TYPE_OPTIONS;
 import static org.wso2.carbon.uuf.spi.HttpResponse.HEADER_X_XSS_PROTECTION;
+import static org.wso2.carbon.uuf.spi.HttpResponse.HEADER_X_FRAME_OPTIONS;
 import static org.wso2.carbon.uuf.spi.HttpResponse.STATUS_BAD_REQUEST;
 import static org.wso2.carbon.uuf.spi.HttpResponse.STATUS_FOUND;
 import static org.wso2.carbon.uuf.spi.HttpResponse.STATUS_INTERNAL_SERVER_ERROR;
@@ -184,6 +185,7 @@ public class RequestDispatcher {
         httpResponse.setHeader(HEADER_CACHE_CONTROL, "no-store, no-cache, must-revalidate, private");
         httpResponse.setHeader(HEADER_EXPIRES, "0");
         httpResponse.setHeader(HEADER_PRAGMA, "no-cache");
+        httpResponse.setHeader(HEADER_X_FRAME_OPTIONS, "DENY");
 
         // if there are any headers configured by the user for this app, then add them also to the response
         app.getConfiguration().getResponseHeaders().getPages().forEach(httpResponse::setHeader);

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/spi/HttpResponse.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/spi/HttpResponse.java
@@ -53,6 +53,7 @@ public interface HttpResponse {
     String HEADER_LAST_MODIFIED = "Last-Modified";
     String HEADER_EXPIRES = "Expires";
     String HEADER_PRAGMA = "Pragma";
+    String HEADER_X_FRAME_OPTIONS = "X-Frame-Options";
 
     /**
      * Sets the <a href="https://tools.ietf.org/html/rfc2616#section-10">HTTP status code</a> of this response to the


### PR DESCRIPTION
Sets response header "X-Fame-Options: DENY" by default. App developers may decide to override the value using app.yaml. 

Resolves #264