### PR TITLE
Adding overloaded method to set security related cookie flags

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/spi/HttpResponse.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/spi/HttpResponse.java
@@ -208,6 +208,17 @@ public interface HttpResponse {
     void addCookie(String name, String value);
 
     /**
+     * Adds a cookie to this response
+     *
+     * @param name       name of the cookie
+     * @param value      value of the cookie
+     * @param path       path of the cookie; if {@code null} path will not be set
+     * @param isSecure   if Secure flag should be set
+     * @param isHttpOnly if HTTPOnly flag should be set
+     */
+    void addCookie(String name, String value, String path, boolean isSecure, boolean isHttpOnly);
+
+    /**
      * Returns the value of the specified cookie of this response.
      *
      * @param name name of the cookie

--- a/components/uuf-httpconnector-msf4j/src/main/java/org/wso2/carbon/uuf/httpconnector/msf4j/MicroserviceHttpResponse.java
+++ b/components/uuf-httpconnector-msf4j/src/main/java/org/wso2/carbon/uuf/httpconnector/msf4j/MicroserviceHttpResponse.java
@@ -115,6 +115,20 @@ public class MicroserviceHttpResponse implements HttpResponse {
     }
 
     @Override
+    public void addCookie(String name, String value, String path, boolean isSecure, boolean isHttpOnly) {
+        if (path != null) {
+            value += "; Path=" + path;
+        }
+        if (isSecure) {
+            value += "; Secure";
+        }
+        if (isHttpOnly) {
+            value += "; HTTPOnly";
+        }
+        addCookie(name, value);
+    }
+
+    @Override
     public String getCookie(String name) {
         return cookies.get(name);
     }


### PR DESCRIPTION
Added an additional overloaded addCookie method, which facilitates setting security related cookie flags without having to add them manually to the value.

Resolves #266 