### PR TITLE
Remove code duplication in LoggerObject class and JsFunctionsImpl class

### DIFF
--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/LoggerObject.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/js/LoggerObject.java
@@ -16,44 +16,23 @@
 
 package org.wso2.carbon.uuf.renderablecreator.hbs.impl.js;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonNull;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
-import jdk.nashorn.api.scripting.ScriptObjectMirror;
+import org.wso2.carbon.uuf.renderablecreator.hbs.internal.serialize.JsonSerializer;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.lang.reflect.Type;
 
 public class LoggerObject {
 
     public static final String NAME = "Log";
-    private static final Gson GSON;
 
     private final org.slf4j.Logger logger;
-
-    static {
-        GsonBuilder gsonBuilder = new GsonBuilder();
-        gsonBuilder.registerTypeAdapter(ScriptObjectMirror.class, new ScriptObjectMirrorSerializer());
-        GSON = gsonBuilder.create();
-    }
 
     LoggerObject(String name) {
         this.logger = org.slf4j.LoggerFactory.getLogger(name);
     }
 
     private static String getLogMessage(Object obj) {
-        if (obj instanceof ScriptObjectMirror) {
-            return GSON.toJson((ScriptObjectMirror) obj);
-        } else {
-            return GSON.toJson(ScriptObjectMirrorSerializer.serialize(obj));
-        }
+        return JsonSerializer.toPrettyJson(obj);
     }
 
     public void info(Object obj) {
@@ -90,78 +69,6 @@ public class LoggerObject {
             // Ignore the 0th element and print the stack trace from the 1st index to the printWriter.
             stackTracePrinter.printStackTrace(printWriter, 1);
             logger.error(stringWriter.toString());
-        }
-    }
-
-    private static class ScriptObjectMirrorSerializer implements JsonSerializer<ScriptObjectMirror> {
-
-        @Override
-        public JsonElement serialize(ScriptObjectMirror jsObj, Type type,
-                                     JsonSerializationContext serializationContext) {
-            return serialize(jsObj, serializationContext);
-        }
-
-        private JsonElement serialize(ScriptObjectMirror jsObj, JsonSerializationContext serializationContext) {
-            if (jsObj == null) {
-                return JsonNull.INSTANCE;
-            }
-            if (jsObj.isFunction()) {
-                String functionSource = jsObj.toString();
-                int openCurlyBraceIndex = functionSource.indexOf('{');
-                if (openCurlyBraceIndex == -1) {
-                    return new JsonPrimitive("function ()");
-                } else {
-                    return new JsonPrimitive(functionSource.substring(0, openCurlyBraceIndex).trim());
-                }
-            }
-            if (jsObj.isArray()) {
-                JsonArray jsonArray = new JsonArray();
-                for (Object item : jsObj.values()) {
-                    if (item instanceof ScriptObjectMirror) {
-                        jsonArray.add(serialize((ScriptObjectMirror) item, serializationContext));
-                    } else {
-                        jsonArray.add(serialize(item));
-                    }
-                }
-                return jsonArray;
-            }
-            if (jsObj.isEmpty()) {
-                return new JsonObject();
-            } else {
-                JsonObject jsonObject = new JsonObject();
-                for (String key : jsObj.getOwnKeys(true)) {
-                    Object member = jsObj.getMember(key);
-                    if (member instanceof ScriptObjectMirror) {
-                        jsonObject.add(key, serialize((ScriptObjectMirror) member, serializationContext));
-                    } else {
-                        jsonObject.add(key, serialize(member));
-                    }
-                }
-                return jsonObject;
-            }
-        }
-
-        public static JsonElement serialize(Object obj) {
-            if (obj == null) {
-                return JsonNull.INSTANCE;
-            }
-            if (ScriptObjectMirror.isUndefined(obj)) {
-                return new JsonPrimitive("undefined");
-            }
-            if (obj instanceof Boolean) {
-                return new JsonPrimitive((Boolean) obj);
-            }
-            if (obj instanceof Number) {
-                return new JsonPrimitive((Number) obj);
-            }
-            if (obj instanceof Character) {
-                return new JsonPrimitive((Character) obj);
-            }
-            if (obj instanceof String) {
-                return new JsonPrimitive((String) obj);
-            } else {
-                return new JsonPrimitive("{" + obj.getClass().getName() + "}");
-            }
         }
     }
 

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/internal/serialize/FunctionScriptObjectMirrorSerializer.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/internal/serialize/FunctionScriptObjectMirrorSerializer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uuf.renderablecreator.hbs.internal.serialize;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import jdk.nashorn.api.scripting.ScriptObjectMirror;
+
+import java.lang.reflect.Type;
+
+/**
+ * JSON serializer for function {@link ScriptObjectMirror} objects.
+ * <p>
+ * For JS functions, this serializer outputs the function signature.
+ *
+ * @since 1.0.0
+ */
+public class FunctionScriptObjectMirrorSerializer extends ScriptObjectMirrorSerializer {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public JsonElement serialize(ScriptObjectMirror jsObj, Type type, JsonSerializationContext context) {
+        if ((jsObj != null) && jsObj.isFunction()) {
+            String functionSource = jsObj.toString();
+            int openCurlyBraceIndex = functionSource.indexOf('{');
+            if (openCurlyBraceIndex == -1) {
+                return new JsonPrimitive("function ()");
+            } else {
+                return new JsonPrimitive(functionSource.substring(0, openCurlyBraceIndex).trim());
+            }
+        } else {
+            return super.serialize(jsObj, type, context);
+        }
+    }
+}

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/internal/serialize/HbsContextSerializer.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/internal/serialize/HbsContextSerializer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uuf.renderablecreator.hbs.internal.serialize;
+
+import com.github.jknack.handlebars.Context;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+
+/**
+ * JSON Serializer for Handlebars {@link Context} objects.
+ *
+ * @since 1.0.0
+ */
+public class HbsContextSerializer implements JsonSerializer<Context> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public JsonElement serialize(Context hbsContext, Type type, JsonSerializationContext serializationContext) {
+        JsonObject serialized = serializationContext.serialize(hbsContext.model()).getAsJsonObject();
+
+        Context extendedContext;
+        try {
+            Field extendedContextField = ((Class) type).getDeclaredField("extendedContext");
+            extendedContextField.setAccessible(true);
+            extendedContext = (Context) extendedContextField.get(hbsContext);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            return serialized;
+        }
+        if (extendedContext == null) {
+            return serialized;
+        }
+
+        serializationContext.serialize(extendedContext.model()).getAsJsonObject().entrySet()
+                .forEach(entry -> serialized.add(entry.getKey(), entry.getValue()));
+        return serialized;
+    }
+}

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/internal/serialize/JsonSerializer.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/internal/serialize/JsonSerializer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uuf.renderablecreator.hbs.internal.serialize;
+
+import com.github.jknack.handlebars.Context;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import jdk.nashorn.api.scripting.ScriptObjectMirror;
+
+/**
+ * JSON serializer for JavaScript object of Nashorn.
+ *
+ * @since 1.0.0
+ */
+public class JsonSerializer {
+
+    private static final Gson safeSerializer, prettySerializer;
+
+    static {
+        safeSerializer = new GsonBuilder()
+                .registerTypeAdapter(ScriptObjectMirror.class, new ScriptObjectMirrorSerializer())
+                .create();
+        prettySerializer = new GsonBuilder()
+                .registerTypeAdapter(ScriptObjectMirror.class, new FunctionScriptObjectMirrorSerializer())
+                .registerTypeAdapter(Context.class, new HbsContextSerializer())
+                .setPrettyPrinting()
+                .disableHtmlEscaping()
+                .serializeNulls()
+                .create();
+    }
+
+    /**
+     * Converts the given object to JSON. The returned JSON string doesn't include any {@code null} values/fields
+     * and any HTML special characters (e.g. &gt;) will be escaped with unicode characters.
+     *
+     * @param src object to be serialized to JSON
+     * @return JSON representation of {@code src}
+     */
+    public static String toSafeJson(Object src) {
+        return safeSerializer.toJson(src);
+    }
+
+    /**
+     * Converts the given object to JSON. The returned JSON string includes indentations and new lines to for
+     * formatting, has any null values/fields of the object, and any HTML special characters won't be escaped.
+     *
+     * @param src object to be serialized to JSON
+     * @return JSON representation of {@code src}
+     */
+    public static String toPrettyJson(Object src) {
+        return prettySerializer.toJson(src);
+    }
+}

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/internal/serialize/ScriptObjectMirrorSerializer.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/internal/serialize/ScriptObjectMirrorSerializer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uuf.renderablecreator.hbs.internal.serialize;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import jdk.nashorn.api.scripting.ScriptObjectMirror;
+
+import java.lang.reflect.Type;
+
+/**
+ * JSON serializer for {@link ScriptObjectMirror} objects.
+ *
+ * @since 1.0.0
+ */
+public class ScriptObjectMirrorSerializer implements JsonSerializer<ScriptObjectMirror> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public JsonElement serialize(ScriptObjectMirror jsObj, Type type, JsonSerializationContext context) {
+        if ((jsObj == null) || ScriptObjectMirror.isUndefined(jsObj) || jsObj.isFunction()) {
+            return JsonNull.INSTANCE;
+        }
+
+        if (jsObj.isArray()) {
+            JsonArray jsonArray = new JsonArray();
+            for (Object item : jsObj.values()) {
+                jsonArray.add(serializeFurther(context.serialize(item), context));
+            }
+            return jsonArray;
+        }
+        if (jsObj.isEmpty()) {
+            return new JsonObject();
+        }
+
+        JsonObject jsonObject = new JsonObject();
+        for (String key : jsObj.getOwnKeys(false)) {
+            jsonObject.add(key, serializeFurther(jsObj.getMember(key), context));
+        }
+        return jsonObject;
+    }
+
+    private JsonElement serializeFurther(Object src, JsonSerializationContext context) {
+        return ScriptObjectMirror.isUndefined(src) ? JsonNull.INSTANCE : context.serialize(src);
+    }
+}


### PR DESCRIPTION
This PR removes code duplication in `LoggerObject.ScriptObjectMirrorSerializer` inner class and `JsFunctionsImpl.ScriptObjectMirrorSerializer` inner class