### PR TITLE
Fix issue in the 'session' demo page in the features-app sample app

### DIFF
--- a/samples/apps/org.wso2.carbon.uuf.sample.features-app.app/src/main/pages/session.hbs
+++ b/samples/apps/org.wso2.carbon.uuf.sample.features-app.app/src/main/pages/session.hbs
@@ -5,7 +5,7 @@
     <h3>Create, Get & Destroy Session.</h3>
     <hr />
     <p>You can get already existing session and create a new user session using your executable.</p>
-    <p>Syntax : <code>createSession(username);</code></p>
+    <p>Syntax : <code>createSession(user);</code></p>
     <p>Syntax : <code>getSession();</code></p>
     <p>Syntax : <code>destroySession();</code></p>
     <p>In your JS file;</p>
@@ -13,18 +13,19 @@
         function onGet(context) {
             var session = getSession();
             if (!session) {
-                session = createSession("admin");
+                var user = login("admin", "admin"); // call some login function
+                session = createSession(user);
             }
             return {"id": session.getUser().getId()};
         }
     </pre>
     <p>Then, you can use this variable in your handlebars;</p>
     <pre>
-        \{{username}}
+        \{{id}}
     </pre>
     <h3>Notes:</h3>
     <ol>
-        <li>The above code will print "{{username}}".</li>
+        <li>The above code will print "{{id}}".</li>
         <li>Once session is created; you can access the same session from any page with getSession().</li>
         <li>Session is implemented on top of Carbon Cache.</li>
     </ol>

--- a/samples/apps/org.wso2.carbon.uuf.sample.features-app.app/src/main/pages/session.js
+++ b/samples/apps/org.wso2.carbon.uuf.sample.features-app.app/src/main/pages/session.js
@@ -18,9 +18,13 @@
 function onGet(env) {
     var session = getSession();
     if (!session) {
-       var SimpleAuthHandler = Java.type("org.wso2.carbon.uuf.sample.simpleauth.bundle.SimpleAuthHandler");
-       var user = SimpleAuthHandler.authenticate("admin", "admin");
-       session = createSession(user);
+        var user = login("admin", "admin"); // call some login function
+        session = createSession(user);
     }
     return {"id": session.getUser().getId()};
+}
+
+function login(username, password) {
+    var SimpleAuthHandler = Java.type("org.wso2.carbon.uuf.sample.simpleauth.bundle.SimpleAuthHandler");
+    return SimpleAuthHandler.authenticate(username, password);
 }


### PR DESCRIPTION
This PR fixes the `Cannot evaluate the variable/helper 'username'` issue which occurs when viewing the `https://localhost:9292/features-app/session` page of the features-app sample.