### PR TITLE
Add AuthorizationException for the Authorizer interface

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/api/exception/AuthorizationException.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/api/exception/AuthorizationException.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.uuf.api.exception;
+
+/**
+ * Indicates an error occurred when performing authorization tasks.
+ *
+ * @since 1.0.0
+ */
+public class AuthorizationException extends UUFException {
+
+    /**
+     * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause(Throwable)}.
+     */
+    public AuthorizationException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause}.
+     *
+     * @param message the detail message of the exception
+     */
+    public AuthorizationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null :
+     * cause.toString())} which typically contains the class and detail message of the {@code cause}.
+     *
+     * @param cause the cause of the exception
+     */
+    public AuthorizationException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message the detail message of the exception
+     * @param cause   the cause of the exception
+     */
+    public AuthorizationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/core/API.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/core/API.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.wso2.carbon.uuf.api.auth.Permission;
 import org.wso2.carbon.uuf.api.auth.Session;
 import org.wso2.carbon.uuf.api.auth.User;
+import org.wso2.carbon.uuf.api.exception.AuthorizationException;
 import org.wso2.carbon.uuf.api.exception.SessionManagementException;
 import org.wso2.carbon.uuf.api.exception.UUFRuntimeException;
 import org.wso2.carbon.uuf.internal.exception.HttpErrorException;
@@ -233,7 +234,13 @@ public class API {
         if (authorizer == null) {
             return false;
         }
-        return authorizer.hasPermission(session.get().getUser(), permission);
+        try {
+            return authorizer.hasPermission(session.get().getUser(), permission);
+        } catch (AuthorizationException e) {
+            throw new PluginExecutionException(
+                    "Cannot check permission for user '" + session.get().getUser().getId() + "' using authorizer '" +
+                    authorizer.getClass().getName() + "'.", e);
+        }
     }
 
     /**

--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/spi/auth/Authorizer.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/spi/auth/Authorizer.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.uuf.spi.auth;
 
 import org.wso2.carbon.uuf.api.auth.Permission;
 import org.wso2.carbon.uuf.api.auth.User;
+import org.wso2.carbon.uuf.api.exception.AuthorizationException;
 
 /**
  * Evaluates permissions for users.
@@ -44,6 +45,7 @@ public interface Authorizer {
      * @param user       user to be checked
      * @param permission permission to be checked
      * @return {@code true} if the user has the permission, otherwise {@code false}
+     * @throws AuthorizationException if an error occurs when checking permission
      */
-    boolean hasPermission(User user, Permission permission);
+    boolean hasPermission(User user, Permission permission) throws AuthorizationException;
 }

--- a/samples/osgi-bundles/org.wso2.carbon.uuf.sample.features-app.bundle/src/main/java/org/wso2/carbon/uuf/sample/featuresapp/bundle/api/auth/DemoAuthorizer.java
+++ b/samples/osgi-bundles/org.wso2.carbon.uuf.sample.features-app.bundle/src/main/java/org/wso2/carbon/uuf/sample/featuresapp/bundle/api/auth/DemoAuthorizer.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import org.osgi.service.component.annotations.Component;
 import org.wso2.carbon.uuf.api.auth.Permission;
 import org.wso2.carbon.uuf.api.auth.User;
+import org.wso2.carbon.uuf.api.exception.AuthorizationException;
 import org.wso2.carbon.uuf.spi.auth.Authorizer;
 
 import java.util.Map;
@@ -51,7 +52,7 @@ public class DemoAuthorizer implements Authorizer {
      * {@inheritDoc}
      */
     @Override
-    public boolean hasPermission(User user, Permission permission) {
+    public boolean hasPermission(User user, Permission permission) throws AuthorizationException {
         if (user == null) {
             return false;
         }


### PR DESCRIPTION
This PR introduces the `org.wso2.carbon.uuf.api.exception.AuthorizationException` for the `org.wso2.carbon.uuf.spi.auth.Authorizer` interface.