### PR TITLE
Log thrown exceptions when rendering pages/fragments

### DIFF
--- a/components/uuf-core/src/main/java/org/wso2/carbon/uuf/core/App.java
+++ b/components/uuf-core/src/main/java/org/wso2/carbon/uuf/core/App.java
@@ -123,9 +123,13 @@ public class App {
     }
 
     /**
+     * Renders the relevant page for the given request.
+     *
      * @param request  HTTP request
      * @param response HTTP response
-     * @return rendered HTML output
+     * @return HTML from page rendering
+     * @throws PageRedirectException if a redirection for another page/URL is needed
+     * @throws HttpErrorException    if some other HTTP error occurred
      */
     public String renderPage(HttpRequest request, HttpResponse response) {
         RequestLookup requestLookup = createRequestLookup(request, response);

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/FragmentHelper.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/FragmentHelper.java
@@ -19,8 +19,6 @@ package org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Helper;
 import com.github.jknack.handlebars.Options;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.wso2.carbon.uuf.core.API;
 import org.wso2.carbon.uuf.core.Fragment;
 import org.wso2.carbon.uuf.core.Lookup;
@@ -35,7 +33,6 @@ import java.util.Optional;
 public class FragmentHelper implements Helper<String> {
 
     public static final String HELPER_NAME = "fragment";
-    private static final Logger log = LoggerFactory.getLogger(FragmentHelper.class);
 
     @Override
     public CharSequence apply(String fragmentName, Options options) throws IOException {
@@ -49,12 +46,8 @@ public class FragmentHelper implements Helper<String> {
                                                            fragmentName);
         if (!fragment.isPresent()) {
             throw new IllegalArgumentException(
-                    "Fragment '" + fragmentName + "' does not exists in Component '" +
+                    "Fragment '" + fragmentName + "' does not exists in component '" +
                             requestLookup.tracker().getCurrentComponentName() + "' or in its dependencies.");
-        }
-
-        if (log.isDebugEnabled()) {
-            log.debug("Fragment \"" + fragment.get() + "\" is called from '" + options.fn.text() + "'.");
         }
 
         Model model = new ContextModel(options.context, options.hash);

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/HbsFragmentRenderable.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/HbsFragmentRenderable.java
@@ -17,6 +17,7 @@
 package org.wso2.carbon.uuf.renderablecreator.hbs.impl;
 
 import com.github.jknack.handlebars.Context;
+import com.github.jknack.handlebars.HandlebarsException;
 import com.github.jknack.handlebars.io.TemplateSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,6 +90,8 @@ public class HbsFragmentRenderable extends HbsPageRenderable {
         try {
             return getTemplate().apply(context);
         } catch (IOException e) {
+            throw new HbsRenderingException("Cannot load fragment Handlebars template '" + getAbsolutePath() + "'.", e);
+        } catch (HandlebarsException e) {
             throw new HbsRenderingException("Cannot render fragment Handlebars template '" + getAbsolutePath() + "'.",
                                             e);
         }

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/HbsLayoutRenderable.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/HbsLayoutRenderable.java
@@ -17,6 +17,7 @@
 package org.wso2.carbon.uuf.renderablecreator.hbs.impl;
 
 import com.github.jknack.handlebars.Context;
+import com.github.jknack.handlebars.HandlebarsException;
 import com.github.jknack.handlebars.io.TemplateSource;
 import org.wso2.carbon.uuf.core.API;
 import org.wso2.carbon.uuf.core.Lookup;
@@ -53,6 +54,8 @@ public class HbsLayoutRenderable extends HbsRenderable {
         try {
             getTemplate().apply(context, writer);
         } catch (IOException e) {
+            throw new HbsRenderingException("Cannot load layout Handlebars template '" + getAbsolutePath() + "'.", e);
+        } catch (HandlebarsException e) {
             throw new HbsRenderingException("Cannot render layout Handlebars template '" + getAbsolutePath() + "'.", e);
         }
         String out = writer.toString(requestLookup.getPlaceholderContents());

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/HbsPageRenderable.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/HbsPageRenderable.java
@@ -17,6 +17,7 @@
 package org.wso2.carbon.uuf.renderablecreator.hbs.impl;
 
 import com.github.jknack.handlebars.Context;
+import com.github.jknack.handlebars.HandlebarsException;
 import com.github.jknack.handlebars.io.TemplateSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,6 +93,8 @@ public class HbsPageRenderable extends HbsRenderable {
         try {
             getTemplate().apply(context, writer);
         } catch (IOException e) {
+            throw new HbsRenderingException("Cannot load page Handlebars template '" + getAbsolutePath() + "'.", e);
+        } catch (HandlebarsException e) {
             throw new HbsRenderingException("Cannot render page Handlebars template '" + getAbsolutePath() + "'.", e);
         }
         String out = writer.toString(requestLookup.getPlaceholderContents());

--- a/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/JsExecutable.java
+++ b/components/uuf-renderablecreator-hbs/src/main/java/org/wso2/carbon/uuf/renderablecreator/hbs/impl/JsExecutable.java
@@ -146,11 +146,10 @@ public class JsExecutable implements Executable {
         } catch (ScriptException e) {
             throw new ExecutionException(
                     "An error occurred when executing the '" + functionName + "' function in JavaScript file '" +
-                            absolutePath + "' with context '" + context + "'.", e);
+                    absolutePath + "' with context '" + context + "'.", e);
         } catch (NoSuchMethodException e) {
             throw new ExecutionException(
-                    "Cannot find the '" + functionName + "' function in the JavaScript file '" + absolutePath + "'.",
-                    e);
+                    "Cannot find '" + functionName + "' function in the JavaScript file '" + absolutePath + "'.", e);
         } finally {
             engineBindings.removeJSFunctionProvider();
         }

--- a/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/init/LayoutHelperTest.java
+++ b/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/init/LayoutHelperTest.java
@@ -43,7 +43,7 @@ public class LayoutHelperTest {
 
     @Test
     public void testSettingMultiple() {
-        String pageTemplateContent = "foo\nbar\n{{layout \"layout-1\"}}bla bla\n{{layout \"layout-2\"}}\nfoobar";
-        Assert.assertThrows(HbsRenderableCreationException.class, () -> createHbsPagePreprocessor(pageTemplateContent));
+        String pageTemplate = "foo\nbar\n{{layout \"layout-1\"}}bla bla\n{{layout \"layout-2\"}}\nfoobar";
+        Assert.assertThrows(HbsRenderableCreationException.class, () -> createHbsPagePreprocessor(pageTemplate));
     }
 }

--- a/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/CssHelperTest.java
+++ b/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/CssHelperTest.java
@@ -18,11 +18,11 @@
 
 package org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime;
 
-import com.github.jknack.handlebars.HandlebarsException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.wso2.carbon.uuf.api.Placeholder;
 import org.wso2.carbon.uuf.core.RequestLookup;
+import org.wso2.carbon.uuf.renderablecreator.hbs.exception.HbsRenderingException;
 
 import static org.mockito.Mockito.when;
 import static org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.RuntimeHelpersTestUtil.createAPI;
@@ -71,14 +71,9 @@ public class CssHelperTest {
 
     @Test
     public void testValidation() {
-        try {
-            createRenderable("{{css null}}").render(null, createLookup(), createRequestLookup(), createAPI());
-            Assert.fail("{{css}} helper accepts null parameters!");
-        } catch (HandlebarsException e) {
-            Assert.assertTrue((e.getCause() instanceof IllegalArgumentException),
-                              "Cause of the thrown exception should be '" + IllegalArgumentException.class +
-                                      "'. Instead found '" + e.getCause().getClass() + "'.");
-        }
+        Assert.assertThrows(HbsRenderingException.class,
+                            () -> createRenderable("{{css null}}")
+                                    .render(null, createLookup(), createRequestLookup(), createAPI()));
     }
 
     private static RequestLookup createRequestLookup() {

--- a/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/FaviconHelperTest.java
+++ b/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/FaviconHelperTest.java
@@ -18,10 +18,10 @@
 
 package org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime;
 
-import com.github.jknack.handlebars.HandlebarsException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.wso2.carbon.uuf.core.RequestLookup;
+import org.wso2.carbon.uuf.renderablecreator.hbs.exception.HbsRenderingException;
 
 import static org.mockito.Mockito.when;
 import static org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.RuntimeHelpersTestUtil.createAPI;
@@ -66,14 +66,9 @@ public class FaviconHelperTest {
 
     @Test
     public void testValidation() {
-        try {
-            createRenderable("{{favicon null}}").render(null, createLookup(), createRequestLookup(), createAPI());
-            Assert.fail("{{favicon}} helper accepts null parameters!");
-        } catch (HandlebarsException e) {
-            Assert.assertTrue((e.getCause() instanceof IllegalArgumentException),
-                              "Cause of the thrown exception should be '" + IllegalArgumentException.class +
-                                      "'. Instead found '" + e.getCause().getClass() + "'.");
-        }
+        Assert.assertThrows(HbsRenderingException.class,
+                            () -> createRenderable("{{favicon null}}")
+                                    .render(null, createLookup(), createRequestLookup(), createAPI()));
     }
 
     private static RequestLookup createRequestLookup() {

--- a/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/JsHelperTest.java
+++ b/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/JsHelperTest.java
@@ -18,11 +18,11 @@
 
 package org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime;
 
-import com.github.jknack.handlebars.HandlebarsException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.wso2.carbon.uuf.api.Placeholder;
 import org.wso2.carbon.uuf.core.RequestLookup;
+import org.wso2.carbon.uuf.renderablecreator.hbs.exception.HbsRenderingException;
 
 import static org.mockito.Mockito.when;
 import static org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.RuntimeHelpersTestUtil.createAPI;
@@ -71,14 +71,9 @@ public class JsHelperTest {
 
     @Test
     public void testValidation() {
-        try {
-            createRenderable("{{js null}}").render(null, createLookup(), createRequestLookup(), createAPI());
-            Assert.fail("{{js}} helper accepts null parameters!");
-        } catch (HandlebarsException e) {
-            Assert.assertTrue((e.getCause() instanceof IllegalArgumentException),
-                              "Cause of the thrown exception should be '" + IllegalArgumentException.class +
-                                      "'. Instead found '" + e.getCause().getClass() + "'.");
-        }
+        Assert.assertThrows(HbsRenderingException.class,
+                            () -> createRenderable("{{js null}}")
+                                    .render(null, createLookup(), createRequestLookup(), createAPI()));
     }
 
     private static RequestLookup createRequestLookup() {

--- a/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/PublicHelperTest.java
+++ b/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/PublicHelperTest.java
@@ -18,10 +18,10 @@
 
 package org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime;
 
-import com.github.jknack.handlebars.HandlebarsException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.wso2.carbon.uuf.core.RequestLookup;
+import org.wso2.carbon.uuf.renderablecreator.hbs.exception.HbsRenderingException;
 
 import static org.mockito.Mockito.when;
 import static org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.RuntimeHelpersTestUtil.createAPI;
@@ -53,14 +53,9 @@ public class PublicHelperTest {
 
     @Test
     public void testValidation() {
-        try {
-            createRenderable("{{public null}}").render(null, createLookup(), createRequestLookup(), createAPI());
-            Assert.fail("{{public}} helper accepts null parameters!");
-        } catch (HandlebarsException e) {
-            Assert.assertTrue((e.getCause() instanceof IllegalArgumentException),
-                              "Cause of the thrown exception should be '" + IllegalArgumentException.class +
-                                      "'. Instead found '" + e.getCause().getClass() + "'.");
-        }
+        Assert.assertThrows(HbsRenderingException.class,
+                            () -> createRenderable("{{public null}}")
+                                    .render(null, createLookup(), createRequestLookup(), createAPI()));
     }
 
     private static RequestLookup createRequestLookup() {

--- a/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/TitleHelperTest.java
+++ b/components/uuf-renderablecreator-hbs/src/test/java/org/wso2/carbon/uuf/renderablecreator/hbs/helpers/runtime/TitleHelperTest.java
@@ -18,10 +18,10 @@
 
 package org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime;
 
-import com.github.jknack.handlebars.HandlebarsException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.wso2.carbon.uuf.core.RequestLookup;
+import org.wso2.carbon.uuf.renderablecreator.hbs.exception.HbsRenderingException;
 
 import static org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.RuntimeHelpersTestUtil.createAPI;
 import static org.wso2.carbon.uuf.renderablecreator.hbs.helpers.runtime.RuntimeHelpersTestUtil.createLookup;
@@ -63,26 +63,16 @@ public class TitleHelperTest {
 
     @Test
     public void testSettingMultiple() {
-        try {
-            createRenderable("{{title \"Some Title\"}} bla bla {{title \"Another Title\"}}")
-                    .render(null, createLookup(), createRequestLookup(), createAPI());
-            Assert.fail("{{title}} helper can be called twice in a page!");
-        } catch (HandlebarsException e) {
-            Assert.assertTrue((e.getCause() instanceof IllegalStateException),
-                              "Cause of the thrown exception should be '" + IllegalStateException.class +
-                                      "'. Instead found '" + e.getCause().getClass() + "'.");
-        }
+        String pageTemplate = "{{title \"Some Title\"}} bla bla {{title \"Another Title\"}}";
+        Assert.assertThrows(HbsRenderingException.class,
+                            () -> createRenderable(pageTemplate)
+                                    .render(null, createLookup(), createRequestLookup(), createAPI()));
     }
 
     @Test
     public void testValidation() {
-        try {
-            createRenderable("{{title null}}").render(null, createLookup(), createRequestLookup(), createAPI());
-            Assert.fail("{{title}} helper accepts null parameters!");
-        } catch (HandlebarsException e) {
-            Assert.assertTrue((e.getCause() instanceof IllegalArgumentException),
-                              "Cause of the thrown exception should be '" + IllegalArgumentException.class +
-                                      "'. Instead found '" + e.getCause().getClass() + "'.");
-        }
+        Assert.assertThrows(HbsRenderingException.class,
+                            () -> createRenderable("{{title null}}")
+                                    .render(null, createLookup(), createRequestLookup(), createAPI()));
     }
 }


### PR DESCRIPTION
Fixes issue #185 

This PR introduces following changes:
- Handling `com.github.jknack.handlebars.HandlebarsException` exception in `HbsPageRenderable`, `HbsFragmentRenderable`, and `HbsLayoutRenderable` classes.
- Ading logs for `PluginExecutionException` and `RenderingException` exceptions in `App.renderPage(...)` method. 