### PR TITLE
Remove Todo comment exists in samples/apps/org.wso2.carbon.uuf.sample.features-app.app/pom.xml file while the related issues are already fixed.

### DIFF
--- a/samples/apps/org.wso2.carbon.uuf.sample.features-app.app/pom.xml
+++ b/samples/apps/org.wso2.carbon.uuf.sample.features-app.app/pom.xml
@@ -18,9 +18,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <!-- TODO: change the module name to org.wso2.carbon.uuf.features-app.feature
-     after fixing the JIRA: https://wso2.org/jira/browse/CMVNPLG-13
-    -->
     <groupId>org.wso2.carbon.uuf.sample</groupId>
     <artifactId>org.wso2.carbon.uuf.sample.features-app.feature</artifactId>
     <version>1.0.0-SNAPSHOT</version>


### PR DESCRIPTION
## Purpose
I think the fix of https://wso2.org/jira/browse/CMVNPLG-13 had been already applied to the associated part, but the comment still exists.

## Goals
 The comment could be removed.

## Approach
Remove the comment:
https://github.com/wso2-attic/carbon-uuf/blob/cdea864e9a02d830aedceb8e6dc661470a7152a6/samples/apps/org.wso2.carbon.uuf.sample.features-app.app/pom.xml#L21-L22